### PR TITLE
Support multiple date selection

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -28,6 +28,7 @@ import {
   DatePickerModal,
   DatePickerModalContent,
   TimePickerModal,
+  // @ts-ignore
 } from 'react-native-paper-dates';
 import { addMonths } from '../../src/Date/dateUtils';
 
@@ -59,6 +60,7 @@ function App({
     hour12: false,
   });
   const [date, setDate] = React.useState<Date | undefined>(undefined);
+  const [dates, setDates] = React.useState<Date[] | undefined>();
   const [range, setRange] = React.useState<{
     startDate: Date | undefined;
     endDate: Date | undefined;
@@ -77,6 +79,7 @@ function App({
   const onDismissTime = React.useCallback(() => {
     setTimeOpen(false);
   }, [setTimeOpen]);
+  const [multiOpen, setMultiOpen] = React.useState(false);
 
   const onDismissRange = React.useCallback(() => {
     setRangeOpen(false);
@@ -89,6 +92,10 @@ function App({
   const onDismissSingle = React.useCallback(() => {
     setSingleOpen(false);
   }, [setSingleOpen]);
+
+  const onDismissMulti = React.useCallback(() => {
+    setMultiOpen(false);
+  }, []);
 
   const onDismissCustom = React.useCallback(() => {
     setCustomOpen(false);
@@ -117,6 +124,12 @@ function App({
     },
     [setSingleOpen, setDate]
   );
+
+  const onChangeMulti = React.useCallback((params) => {
+    setMultiOpen(false);
+    setDates(params.dates);
+    console.log('[on-change-multi]', params);
+  }, []);
 
   const onConfirmTime = React.useCallback(
     ({ hours, minutes }) => {
@@ -238,6 +251,14 @@ function App({
             >
               Pick single date
             </Button>
+            <Button
+              onPress={() => setMultiOpen(true)}
+              uppercase={false}
+              mode="outlined"
+              style={styles.pickButton}
+            >
+              Pick Multi date
+            </Button>
             <View style={styles.buttonSeparator} />
             <Button
               onPress={() => setRangeOpen(true)}
@@ -334,6 +355,19 @@ function App({
         onDismiss={onDismissSingle}
         date={date}
         onConfirm={onChangeSingle}
+        // saveLabel="Save" // optional
+        // label="Select date" // optional
+        // animationType="slide" // optional, default is 'slide' on ios/android and 'none' on web
+      />
+
+      <DatePickerModal
+        // locale={'en'} optional, default: automatic
+        mode="multi"
+        visible={multiOpen}
+        onDismiss={onDismissMulti}
+        dates={dates}
+        onConfirm={onChangeMulti}
+        // onChange={onChangeMulti}
         // saveLabel="Save" // optional
         // label="Select date" // optional
         // animationType="slide" // optional, default is 'slide' on ios/android and 'none' on web

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -239,6 +239,15 @@ function App({
                   : '-'}
               </Text>
             </Row>
+            <Row>
+              <Label>Dates</Label>
+              <Text>
+                {dates
+                  ?.map((date) => date && dateFormatter.format(date))
+                  .filter(Boolean)
+                  .join(', ')}
+              </Text>
+            </Row>
           </View>
           <Enter />
           <Enter />

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -28,7 +28,6 @@ import {
   DatePickerModal,
   DatePickerModalContent,
   TimePickerModal,
-  // @ts-ignore
 } from 'react-native-paper-dates';
 import { addMonths } from '../../src/Date/dateUtils';
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -251,13 +251,14 @@ function App({
             >
               Pick single date
             </Button>
+            <View style={styles.buttonSeparator} />
             <Button
               onPress={() => setMultiOpen(true)}
               uppercase={false}
               mode="outlined"
               style={styles.pickButton}
             >
-              Pick Multi date
+              Pick multiple dates
             </Button>
             <View style={styles.buttonSeparator} />
             <Button

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -17,9 +13,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "paths": {
+      "react-native-paper-dates": ["../"]
+    }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,10 +17,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
-    "paths": {
-      "react-native-paper-dates": ["../"]
-    }
+    "jsx": "react"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/src/Date/Calendar.tsx
+++ b/src/Date/Calendar.tsx
@@ -38,7 +38,13 @@ export type RangeChange = (params: {
 
 export type SingleChange = (params: { date: CalendarDate }) => any
 
-export type MultiChange = (params: { dates: CalendarDate[] }) => any
+export type MultiChange = (params: {
+  dates: CalendarDate[]
+  datePressed: CalendarDate
+  change: 'added' | 'removed'
+}) => any
+
+export type MultiConfirm = (params: { dates: CalendarDate[] }) => any
 
 export interface CalendarSingleProps extends BaseCalendarProps {
   mode: 'single'
@@ -160,7 +166,7 @@ function Calendar(
         })
       } else if (mode === 'multi') {
         datesRef.current = datesRef.current || []
-        const exists = datesRef.current?.some((ed) => areDatesOnSameDay(ed, d))
+        const exists = datesRef.current.some((ed) => areDatesOnSameDay(ed, d))
 
         const newDates = exists
           ? datesRef.current.filter((ed) => !areDatesOnSameDay(ed, d))
@@ -169,6 +175,8 @@ function Calendar(
         newDates.sort((a, b) => a.getTime() - b.getTime())
         ;(onChangeRef.current as MultiChange)({
           dates: newDates,
+          datePressed: d,
+          change: exists ? 'removed' : 'added',
         })
       }
     },

--- a/src/Date/Calendar.tsx
+++ b/src/Date/Calendar.tsx
@@ -190,6 +190,7 @@ function Calendar(
             startDate={startDate}
             endDate={endDate}
             date={date}
+            dates={dates}
             onPressYear={onPressYear}
             selectingYear={selectingYear}
             onPressDate={onPressDate}

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -12,6 +12,7 @@ import {
 import { useTheme } from 'react-native-paper'
 import DatePickerModalContent, {
   DatePickerModalContentExcludeInRangeProps,
+  DatePickerModalContentMultiProps,
   DatePickerModalContentRangeProps,
   DatePickerModalContentSingleProps,
 } from './DatePickerModalContent'
@@ -30,6 +31,10 @@ interface DatePickerModalSingleProps
   extends DatePickerModalContentSingleProps,
     DatePickerModalProps {}
 
+interface DatePickerModalMultiProps
+  extends DatePickerModalContentMultiProps,
+    DatePickerModalProps {}
+
 interface DatePickerModalRangeProps
   extends DatePickerModalContentRangeProps,
     DatePickerModalProps {}
@@ -43,6 +48,7 @@ export function DatePickerModal(
     | DatePickerModalRangeProps
     | DatePickerModalSingleProps
     | DatePickerModalExcludeInRangeProps
+    | DatePickerModalMultiProps
 ) {
   const theme = useTheme()
   const dimensions = useWindowDimensions()

--- a/src/Date/DatePickerModalContent.tsx
+++ b/src/Date/DatePickerModalContent.tsx
@@ -4,6 +4,7 @@ import Calendar, {
   BaseCalendarProps,
   CalendarDate,
   ExcludeInRangeChange,
+  MultiChange,
   RangeChange,
   SingleChange,
 } from './Calendar'
@@ -22,6 +23,7 @@ export type LocalState = {
   endDate: CalendarDate
   date: CalendarDate
   excludedDates: Date[]
+  dates: CalendarDate[]
 }
 
 interface DatePickerModalContentBaseProps {
@@ -51,6 +53,16 @@ export interface DatePickerModalContentSingleProps
   onConfirm: SingleChange
 }
 
+export interface DatePickerModalContentMultiProps
+  extends HeaderPickProps,
+    BaseCalendarProps,
+    DatePickerModalContentBaseProps {
+  mode: 'multi'
+  dates?: Date[] | null | undefined
+  onChange?: MultiChange
+  onConfirm: MultiChange
+}
+
 export interface DatePickerModalContentExcludeInRangeProps
   extends HeaderPickProps,
     BaseCalendarProps,
@@ -68,6 +80,7 @@ export function DatePickerModalContent(
     | DatePickerModalContentRangeProps
     | DatePickerModalContentSingleProps
     | DatePickerModalContentExcludeInRangeProps
+    | DatePickerModalContentMultiProps
 ) {
   const {
     mode,
@@ -87,6 +100,7 @@ export function DatePickerModalContent(
     startDate: anyProps.startDate,
     endDate: anyProps.endDate,
     excludedDates: anyProps.excludedDates,
+    dates: anyProps.dates,
   })
 
   // update local state if changed from outside or if modal is opened
@@ -96,12 +110,14 @@ export function DatePickerModalContent(
       startDate: anyProps.startDate,
       endDate: anyProps.endDate,
       excludedDates: anyProps.excludedDates,
+      dates: anyProps.dates,
     })
   }, [
     anyProps.date,
     anyProps.startDate,
     anyProps.endDate,
     anyProps.excludedDates,
+    anyProps.dates,
   ])
 
   const [collapsed, setCollapsed] = React.useState<boolean>(true)
@@ -127,6 +143,10 @@ export function DatePickerModalContent(
     } else if (mode === 'excludeInRange') {
       ;(onConfirm as DatePickerModalContentExcludeInRangeProps['onConfirm'])({
         excludedDates: state.excludedDates,
+      })
+    } else if (mode === 'multi') {
+      ;(onConfirm as DatePickerModalContentMultiProps['onConfirm'])({
+        dates: state.dates || [],
       })
     }
   }, [state, mode, onConfirm])
@@ -170,6 +190,7 @@ export function DatePickerModalContent(
             excludedDates={state.excludedDates}
             onChange={onInnerChange}
             disableWeekDays={disableWeekDays}
+            dates={state.dates}
           />
         }
         calendarEdit={

--- a/src/Date/DatePickerModalContent.tsx
+++ b/src/Date/DatePickerModalContent.tsx
@@ -5,6 +5,7 @@ import Calendar, {
   CalendarDate,
   ExcludeInRangeChange,
   MultiChange,
+  MultiConfirm,
   RangeChange,
   SingleChange,
 } from './Calendar'
@@ -60,7 +61,7 @@ export interface DatePickerModalContentMultiProps
   mode: 'multi'
   dates?: Date[] | null | undefined
   onChange?: MultiChange
-  onConfirm: MultiChange
+  onConfirm: MultiConfirm
 }
 
 export interface DatePickerModalContentExcludeInRangeProps

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -64,7 +64,7 @@ export default function DatePickerModalHeader(props: HeaderContentProps) {
         </View>
       </View>
       <View style={styles.fill} />
-      {mode !== 'excludeInRange' ? (
+      {mode !== 'excludeInRange' && mode !== 'multi' ? (
         <IconButton
           icon={collapsed ? 'pencil' : 'calendar'}
           color={color}

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -36,6 +36,9 @@ function getLabel(mode: ModeType, configuredLabel?: string) {
   if (mode === 'excludeInRange') {
     return 'Select excluded dates'
   }
+  if (mode === 'multi') {
+    return 'Select dates'
+  }
   return '...?'
 }
 
@@ -60,6 +63,9 @@ export default function DatePickerModalHeader(props: HeaderContentProps) {
           ) : null}
           {mode === 'excludeInRange' ? (
             <HeaderContentExcludeInRange {...props} color={color} />
+          ) : null}
+          {mode === 'multi' ? (
+            <HeaderContentMulti {...props} color={color} />
           ) : null}
         </View>
       </View>
@@ -95,6 +101,37 @@ export function HeaderContentSingle({
     <Text style={[styles.singleHeaderText, { color: dateColor }]}>
       {state.date ? formatter.format(state.date) : emptyLabel}
     </Text>
+  )
+}
+
+export function HeaderContentMulti({
+  state,
+  emptyLabel = ' ',
+  color,
+  locale,
+}: HeaderContentProps & { color: string }) {
+  const dateCount = state.dates?.length || 0
+  const lighterColor = Color(color).fade(0.5).rgb().toString()
+  const dateColor = dateCount ? color : lighterColor
+
+  const formatter = React.useMemo(() => {
+    return new Intl.DateTimeFormat(locale, {
+      month: 'short',
+      day: 'numeric',
+    })
+  }, [locale])
+
+  let label = emptyLabel
+  if (dateCount) {
+    if (dateCount <= 2) {
+      label = state.dates.map((date) => formatter.format(date)).join(', ')
+    } else {
+      label = formatter.format(state.dates[0]) + ` (+ ${dateCount - 1} more)`
+    }
+  }
+
+  return (
+    <Text style={[styles.singleHeaderText, { color: dateColor }]}>{label}</Text>
   )
 }
 

--- a/src/Date/Month.tsx
+++ b/src/Date/Month.tsx
@@ -53,6 +53,11 @@ interface MonthSingleProps extends BaseMonthProps {
   date?: Date | null | undefined
 }
 
+interface MonthMultiProps extends BaseMonthProps {
+  mode: 'multi'
+  dates?: Date[] | null | undefined
+}
+
 interface MonthExcludeInRangeProps extends BaseMonthProps {
   mode: 'excludeInRange'
   startDate: Date
@@ -75,7 +80,13 @@ function Month({
   disableWeekDays,
   excludedDates,
   locale,
-}: MonthSingleProps | MonthRangeProps | MonthExcludeInRangeProps) {
+  // @ts-ignore
+  dates,
+}:
+  | MonthSingleProps
+  | MonthRangeProps
+  | MonthExcludeInRangeProps
+  | MonthMultiProps) {
   const theme = useTheme()
   const textColorOnPrimary = useTextColorOnPrimary()
   const realIndex = getRealIndex(index)
@@ -114,11 +125,20 @@ function Month({
           const selectedEndDay = areDatesOnSameDay(day, endDate)
           const selectedDay = areDatesOnSameDay(day, date)
 
+          const multiDates = dates as Date[] | undefined
+
+          const selectedMultiDay = !!multiDates?.some((d) =>
+            areDatesOnSameDay(day, d)
+          )
+
           let disabled = mode === 'excludeInRange'
           let selected =
             mode === 'range' || mode === 'excludeInRange'
               ? selectedStartDay || selectedEndDay
               : selectedDay
+          if (mode === 'multi') {
+            selected = selectedMultiDay
+          }
           let inRange =
             mode === 'range' || mode === 'excludeInRange'
               ? isDateBetween(day, {
@@ -188,7 +208,7 @@ function Month({
         }),
       }
     })
-  }, [mode, index, startDate, endDate, date, month, year, excludedDates])
+  }, [year, month, index, startDate, endDate, date, dates, mode, excludedDates])
 
   return (
     <View style={[styles.month, { height: getMonthHeight(scrollMode, index) }]}>


### PR DESCRIPTION
This PR plans to add multiple date support, to close #43.

- [x] Add `dates` prop to `Calendar`, allowing it to receive multiple dates rather than just 1
- [x] Add `mode="multiple"` to `DatePicker`
- [x] Add label to `DatePickerModalHeaderContent` when selecting multiple dates
- [x] ~~Add option to require at least 1 date (i.e. don't remove the last date if it's changed.) Maybe this should just be done by users by not changing the date if `length < 1`~~ Instead, we notify users with the day just clicked and whether it was added or removed 

@RichardLindhout Can you confirm that we can close this if I can get it done and make it work well?

Thanks!