### PR TITLE
fix: input date issue

### DIFF
--- a/src/Date/CalendarEdit.tsx
+++ b/src/Date/CalendarEdit.tsx
@@ -148,7 +148,7 @@ function CalendarInputPure(
 
   const inputFormat = React.useMemo(() => {
     // TODO: something cleaner and more universal?
-    const inputDate = formatter.format(new Date(Date.UTC(2020, 10 - 1, 1)))
+    const inputDate = formatter.format(new Date(2020, 10 - 1, 1))
     return inputDate
       .replace('2020', 'YYYY')
       .replace('10', 'MM')


### PR DESCRIPTION
There is an issue that occurs (might only be in Western Hemisphere) where the date always becomes Nov 30th

It's because the inputDate string replacement does not happen because `new Date(Date.UTC(2020, 10 - 1, 1))` in Western Hemisphere is the previous day so `'10'`  and `'01'`  are not found in `inputDate` and are not replaced, as a result `dayIndex` and `monthIndex` (lines 160 and 161) are evaluated to `-1`

[Previous behaviour](https://www.loom.com/share/91f0db6feb6e4030a2cfdf0c2b67c058)
[Corrected behaviour](https://www.loom.com/share/3328c3c07e9249bfb0e1bff30e087c22)