### PR TITLE
fix: pass locale property to CalendarEdit

### DIFF
--- a/src/Date/CalendarEdit.tsx
+++ b/src/Date/CalendarEdit.tsx
@@ -21,6 +21,7 @@ function CalendarEdit({
   collapsed,
   onChange,
   validRange,
+  locale,
 }: {
   mode: ModeType
   label?: string
@@ -30,6 +31,7 @@ function CalendarEdit({
   collapsed: boolean
   onChange: (s: LocalState) => any
   validRange: ValidRangeType | undefined
+  locale?: undefined | string
 }) {
   const dateInput = React.useRef<TextInputNative | null>(null)
   const startInput = React.useRef<TextInputNative | null>(null)
@@ -84,6 +86,7 @@ function CalendarEdit({
             onChange={(date) => onChange({ ...state, date })}
             onSubmitEditing={onSubmitInput}
             validRange={validRange}
+            locale={locale}
           />
         ) : null}
         {mode === 'range' ? (
@@ -96,6 +99,7 @@ function CalendarEdit({
               returnKeyType={'next'}
               onSubmitEditing={onSubmitStartInput}
               validRange={validRange}
+              locale={locale}
             />
             <View style={styles.separator} />
             <CalendarInput
@@ -106,6 +110,7 @@ function CalendarEdit({
               isEndDate
               onSubmitEditing={onSubmitEndInput}
               validRange={validRange}
+              locale={locale}
             />
           </>
         ) : null}

--- a/src/Date/DatePickerModalContent.tsx
+++ b/src/Date/DatePickerModalContent.tsx
@@ -28,6 +28,7 @@ export type LocalState = {
 
 interface DatePickerModalContentBaseProps {
   inputFormat?: string
+  locale?: undefined | string
   onDismiss: () => any
   disableSafeTop?: boolean
 }
@@ -180,6 +181,7 @@ export function DatePickerModalContent(
             collapsed={collapsed}
             onChange={onInnerChange}
             validRange={validRange}
+            locale={locale}
           />
         }
       />


### PR DESCRIPTION
Locale property was defined for DatePickerModal component, but not passed down to CalendarEdit. CalendarEdit needs locale for proper input format detection.