### PR TITLE
Adding a date range opacity prop for light mode

### DIFF
--- a/src/Date/Calendar.tsx
+++ b/src/Date/Calendar.tsx
@@ -37,6 +37,7 @@ export type BaseCalendarProps = {
   dates?: CalendarDates
   startDate?: CalendarDate
   endDate?: CalendarDate
+  rangeOpacity?: number
 }
 
 export type CalendarDate = Date | undefined
@@ -68,12 +69,14 @@ export interface CalendarRangeProps extends BaseCalendarProps {
   startDate: CalendarDate
   endDate: CalendarDate
   onChange: RangeChange
+  rangeOpacity: number
 }
 
 export interface CalendarMultiProps extends BaseCalendarProps {
   mode: 'multiple'
   dates: CalendarDates
   onChange: MultiChange
+  rangeOpacity: number
 }
 
 function Calendar(
@@ -89,6 +92,7 @@ function Calendar(
     disableWeekDays,
     dates,
     validRange,
+    rangeOpacity,
   } = props
 
   const theme = useTheme()
@@ -97,7 +101,7 @@ function Calendar(
     if (theme.dark) {
       return darkenBy(Color(theme.colors.primary), 0.9).hex()
     }
-    return lightenBy(Color(theme.colors.primary), 0.9).hex()
+    return lightenBy(Color(theme.colors.primary), rangeOpacity ? rangeOpacity : 0.9).hex()
   }, [theme])
 
   const scrollMode =

--- a/src/Date/DatePickerModalContent.tsx
+++ b/src/Date/DatePickerModalContent.tsx
@@ -42,6 +42,7 @@ export interface DatePickerModalContentRangeProps
   endDate: CalendarDate
   onChange?: RangeChange
   onConfirm: RangeChange
+  rangeOpacity?: number
 }
 
 export interface DatePickerModalContentSingleProps
@@ -62,6 +63,7 @@ export interface DatePickerModalContentMultiProps
   dates?: CalendarDates
   onChange?: MultiChange
   onConfirm: MultiConfirm
+  rangeOpacity?: number
 }
 
 export function DatePickerModalContent(
@@ -79,6 +81,7 @@ export function DatePickerModalContent(
     disableWeekDays,
     locale,
     validRange,
+    rangeOpacity,
   } = props
 
   const anyProps = props as any
@@ -169,6 +172,7 @@ export function DatePickerModalContent(
             disableWeekDays={disableWeekDays}
             dates={state.dates}
             validRange={validRange}
+            rangeOpacity={rangeOpacity}
           />
         }
         calendarEdit={


### PR DESCRIPTION
Per #85, added an optional rangeOpacity prop to allow for different opacity levels for light mode. 

p.s. This is my first time ever contributing to an open source project so feedback is welcomed!