### PR TITLE
Button accessibility

### DIFF
--- a/src/Date/CalendarHeader.tsx
+++ b/src/Date/CalendarHeader.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native'
 import { IconButton, useTheme } from 'react-native-paper'
 import DayNames, { dayNamesHeight } from './DayNames'
 import type { DisableWeekDaysType } from './dateUtils'
+import { getTranslation } from '../translations/utils'
 
 const buttonContainerHeight = 56
 const buttonContainerMarginTop = 4
@@ -48,7 +49,7 @@ function CalendarHeader({
           >
             <IconButton
               icon="chevron-left"
-              accessibilityLabel="Previous"
+              accessibilityLabel={getTranslation(locale, 'previous')}
               onPress={onPrev}
               // RN types bug
               hasTVPreferredFocus={undefined}
@@ -64,7 +65,7 @@ function CalendarHeader({
           >
             <IconButton
               icon="chevron-right"
-              accessibilityLabel="Next"
+              accessibilityLabel={getTranslation(locale, 'next')}
               onPress={onNext}
               // RN types bug
               hasTVPreferredFocus={undefined}

--- a/src/Date/CalendarHeader.tsx
+++ b/src/Date/CalendarHeader.tsx
@@ -48,6 +48,7 @@ function CalendarHeader({
           >
             <IconButton
               icon="chevron-left"
+              accessibilityLabel="Previous"
               onPress={onPrev}
               // RN types bug
               hasTVPreferredFocus={undefined}
@@ -63,6 +64,7 @@ function CalendarHeader({
           >
             <IconButton
               icon="chevron-right"
+              accessibilityLabel="Next"
               onPress={onNext}
               // RN types bug
               hasTVPreferredFocus={undefined}

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -80,7 +80,9 @@ export default function DatePickerModalContentHeader(
         <IconButton
           icon={collapsed ? 'pencil' : 'calendar'}
           accessibilityLabel={
-            collapsed ? 'Type in date' : 'Pick date from calendar'
+            collapsed
+              ? getTranslation(props.locale, 'typeInDate')
+              : getTranslation(props.locale, 'pickDateFromCalendar')
           }
           color={color}
           onPress={onToggle}

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -79,6 +79,9 @@ export default function DatePickerModalContentHeader(
       {allowEditing ? (
         <IconButton
           icon={collapsed ? 'pencil' : 'calendar'}
+          accessibilityLabel={
+            collapsed ? 'Type in date' : 'Pick date from calendar'
+          }
           color={color}
           onPress={onToggle}
           // RN types bug

--- a/src/Date/DatePickerModalHeader.tsx
+++ b/src/Date/DatePickerModalHeader.tsx
@@ -31,7 +31,7 @@ export default function DatePickerModalHeader(
           <Appbar style={styles.appbarHeader}>
             <Appbar.Action
               icon="close"
-              accessibilityLabel="Close"
+              accessibilityLabel={getTranslation(locale, 'close')}
               onPress={props.onDismiss}
               color={color}
               testID="react-native-paper-dates-close"

--- a/src/Date/DatePickerModalHeader.tsx
+++ b/src/Date/DatePickerModalHeader.tsx
@@ -31,6 +31,7 @@ export default function DatePickerModalHeader(
           <Appbar style={styles.appbarHeader}>
             <Appbar.Action
               icon="close"
+              accessibilityLabel="Close"
               onPress={props.onDismiss}
               color={color}
               testID="react-native-paper-dates-close"

--- a/src/Date/Day.tsx
+++ b/src/Date/Day.tsx
@@ -73,6 +73,7 @@ function Day(props: {
           styles.button,
           { backgroundColor: inRange ? selectColor : undefined },
         ]}
+        accessibilityRole="button"
         // RN types bug
         hasTVPreferredFocus={undefined}
         tvParallaxProperties={undefined}

--- a/src/Date/Month.tsx
+++ b/src/Date/Month.tsx
@@ -260,6 +260,8 @@ function Month(props: MonthSingleProps | MonthRangeProps | MonthMultiProps) {
         <TouchableRipple
           disabled={!isHorizontal}
           onPress={isHorizontal ? () => onPressYear(year) : undefined}
+          accessibilityRole="button"
+          accessibilityLabel={`${monthName} ${year}`}
           style={[
             styles.yearButton,
             {

--- a/src/Date/YearPicker.tsx
+++ b/src/Date/YearPicker.tsx
@@ -74,6 +74,8 @@ function YearPure({
     <View style={styles.year}>
       <TouchableRipple
         onPress={() => onPressYear(year)}
+        accessibilityRole="button"
+        accessibilityLabel={String(year)}
         style={styles.yearButton}
         // RN types bug
         hasTVPreferredFocus={undefined}

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -11,5 +11,10 @@ const en: TranslationsType = {
   mustBeLowerThan: 'Must be earlier then',
   mustBeBetween: 'Must be between',
   dateIsDisabled: 'Day is not allowed',
+  previous: 'Previous',
+  next: 'Next',
+  typeInDate: 'Type in date',
+  pickDateFromCalendar: 'Pick date from calendar',
+  close: 'Close',
 }
 export default en

--- a/src/translations/enGB.ts
+++ b/src/translations/enGB.ts
@@ -11,5 +11,10 @@ const enGB: TranslationsType = {
   mustBeLowerThan: 'Must be earlier then',
   mustBeBetween: 'Must be between',
   dateIsDisabled: 'Day is not allowed',
+  previous: 'Previous',
+  next: 'Next',
+  typeInDate: 'Type in date',
+  pickDateFromCalendar: 'Pick date from calendar',
+  close: 'Close',
 }
 export default enGB

--- a/src/translations/utils.ts
+++ b/src/translations/utils.ts
@@ -8,6 +8,11 @@ export type TranslationsType = {
   mustBeLowerThan: string
   mustBeBetween: string
   dateIsDisabled: string
+  previous: string
+  next: string
+  typeInDate: string
+  pickDateFromCalendar: string
+  close: string
 }
 
 let translationsPerLocale: Record<string, TranslationsType> = {}


### PR DESCRIPTION
This PR makes some buttons in the app more accessible, by marking them as buttons for the sake of accessibility, and by providing text labels for them. The specific use case I'm working with is iOS Voice Control, which lets you tap items on the screen based on their name.

Voice Control provides a names overlay to make it easy to visualize what elements have which names. Before this PR the overlay shows:

![image](https://user-images.githubusercontent.com/15832198/140610284-c0f39d70-8f2b-481a-a32a-3099cc87e16c.png)


Note that:

- Most icon buttons don't have a label
- Days of the month and the year dropdown aren't indicated as buttons at all

After this PR, the overlay shows:

![image](https://user-images.githubusercontent.com/15832198/140610295-6d04c05b-f11e-427c-a9a2-228bc7663450.png)


Note that I haven't added accessibility to all components in the app, just the ones I have experience with from the app I'm using RN Paper in.

Thanks for the great library!