### PR TITLE
Add german translations

### DIFF
--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1,0 +1,20 @@
+import type { TranslationsType } from './utils'
+
+const de: TranslationsType = {
+    save: 'Speichern',
+    selectSingle: 'Wähle Datum',
+    selectMultiple: 'Wähle Daten',
+    selectRange: 'Wähle Zeitspanne',
+    notAccordingToDateFormat: (inputFormat: string) =>
+      `Das Format sollte ${inputFormat} sein`,
+    mustBeHigherThan: 'Muss später sein als',
+    mustBeLowerThan: 'Muss früher sein als',
+    mustBeBetween: 'Muss in dieser Zeitspanne liegen',
+    dateIsDisabled: 'Datum nicht wählbar',
+    previous: 'Vorheriges',
+    next: 'Nächstes',
+    typeInDate: 'Datum eingeben',
+    pickDateFromCalendar: 'Datum vom Kalender auswählen',
+    close: 'Schliessen',
+}
+export default nl


### PR DESCRIPTION
The messages for mustBeHigherThan and mustBeLowerThan could be improved somewhat by being able to add the date in the middle i.e.
```
    mustBeHigherThan: (date: Date) => `Muss nach dem ${date} sein`,
    mustBeLowerThan: (date: Date) => `Muss vor dem ${date} sein`,
```
But it's a rather minute improvement that wouldn't be worth it if it means a lot of effort in the code.