### PR TITLE
fix: update input label for pt locale

### DIFF
--- a/src/Date/dateUtils.tsx
+++ b/src/Date/dateUtils.tsx
@@ -218,17 +218,19 @@ export function getEndOfDay(d: Date): Date {
 }
 export function useInputFormat({
   formatter,
+  locale,
 }: {
   formatter: Intl.DateTimeFormat
+  locale?: string
 }) {
   return React.useMemo(() => {
     // TODO: something cleaner and more universal?
     const inputDate = formatter.format(new Date(2020, 10 - 1, 1))
     return inputDate
-      .replace('2020', 'YYYY')
+      .replace('2020', locale === 'pt' ? 'AAAA' : 'YYYY')
       .replace('10', 'MM')
       .replace('01', 'DD')
-  }, [formatter])
+  }, [formatter, locale])
 }
 
 export function differenceInMonths(firstDate: Date, secondDate: Date) {

--- a/src/Date/inputUtils.ts
+++ b/src/Date/inputUtils.ts
@@ -20,12 +20,15 @@ export default function useDateInput({
     useRangeChecker(validRange)
   const [error, setError] = React.useState<null | string>(null)
   const formatter = useInputFormatter({ locale })
-  const inputFormat = useInputFormat({ formatter })
+  const inputFormat = useInputFormat({ formatter, locale })
   const formattedValue = formatter.format(value)
   const onChangeText = (date: string) => {
     const dayIndex = inputFormat.indexOf('DD')
     const monthIndex = inputFormat.indexOf('MM')
-    const yearIndex = inputFormat.indexOf('YYYY')
+    const yearIndex =
+      locale === 'pt'
+        ? inputFormat.indexOf('AAAA')
+        : inputFormat.indexOf('YYYY')
 
     const day = Number(date.slice(dayIndex, dayIndex + 2))
     const year = Number(date.slice(yearIndex, yearIndex + 4))


### PR DESCRIPTION
Hello! In Portuguese they use `AAAA` instead of `YYYY` for dates. This PR updates the inputFormat to use `AAAA` when the Portuguese locale is selected. 