### PR TITLE
Fixed 60 Minutes, it should be 59 Minutes

### DIFF
--- a/src/Time/TimeInputs.tsx
+++ b/src/Time/TimeInputs.tsx
@@ -118,8 +118,8 @@ function TimeInputs({
         onSubmitEditing={onSubmitEndInput}
         onChanged={(newMinutesFromInput) => {
           let newMinutes = newMinutesFromInput
-          if (newMinutesFromInput > 60) {
-            newMinutes = 60
+          if (newMinutesFromInput > 59) {
+            newMinutes = 59
           }
           onChange({
             hours,


### PR DESCRIPTION
Hey, in the time picker component when in keyboard mode it allows setting the minutes to 60, but the correct is up to 59 minutes max.

<img src="https://user-images.githubusercontent.com/4554784/158359166-a1d6fca6-6614-4c18-bf55-7e4135e85a88.png" width="250" />
