### PR TITLE
intl dependency crash for android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "react-native-paper-dates",
+  "version": "0.9.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "intl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
+      "integrity": "sha512-rK0KcPHeBFBcqsErKSpvZnrOmWOj+EmDkyJ57e90YWaQNqbcivcqmKDlHEeNprDWOsKzPsh1BfSpPQdDvclHVw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
   },
   "dependencies": {
     "caniuse-lite": "^1.0.30001383",
-    "color": "^3.2.1"
+    "color": "^3.2.1",
+    "intl": "^1.2.5"
   }
 }


### PR DESCRIPTION
When opening either eith DatePickerModal or TimePickerModal on android returns with a crash to download this dependency npm install intl and add this inside src/Time/TimePicker.tsx :

import 'intl';
import 'intl/locale-data/jsonp/en';

**FIXES** the problem!