### PR TITLE
Fixing jumping to the end on textinput

### DIFF
--- a/src/TextInputMask.tsx
+++ b/src/TextInputMask.tsx
@@ -72,7 +72,7 @@ function TextInputWithMask(
     value,
     mask,
     ...rest
-  }: React.ComponentProps<typeof TextInput> & { mask: string },
+  }: React.ComponentProps<typeof TextInput> & { mask: string; value: string },
   ref: any
 ) {
   const [controlledValue, setControlledValue] = React.useState<string>(
@@ -80,12 +80,15 @@ function TextInputWithMask(
   )
 
   const onInnerChange = (text: string) => {
-    const enhancedText = enhanceTextWithMask(text, mask, controlledValue)
-    setControlledValue(enhancedText)
-
     if (text.length === mask.length) {
       onChangeText && onChangeText(text)
     }
+    setControlledValue(text)
+  }
+
+  const onInnerBlur = () => {
+    const enhancedText = enhanceTextWithMask(value, mask, controlledValue)
+    setControlledValue(enhancedText)
   }
 
   React.useEffect(() => {
@@ -98,6 +101,7 @@ function TextInputWithMask(
       {...rest}
       value={controlledValue}
       onChangeText={onInnerChange}
+      onBlur={onInnerBlur}
     />
   )
 }


### PR DESCRIPTION
Thanks for this amazing project!! 
------------------
PR INCLUDES:

A fix for this issue: #98 
Solves issues: 
- By selecting the manual date selection tool and updating the textInput component, if we start updating the text from the middle, the state updating will cause the cursor to jump to the end of the text. By updating the local state and mask properly onBlur, we will prevent this problem

Before: 

https://user-images.githubusercontent.com/60409704/197133897-9ab6c1e8-bfb5-4a3e-9c69-ba5fb9fa72cc.mov

After: 

https://user-images.githubusercontent.com/60409704/197134034-085e45f0-f7f8-4b3a-9702-25e4393ef8a7.mov

