### PR TITLE
Fix AM bug.

### DIFF
--- a/src/Time/AnalogClock.tsx
+++ b/src/Time/AnalogClock.tsx
@@ -63,15 +63,13 @@ function AnalogClock({
         let previousHourType = getHourType(hoursRef.current)
         let pickedHours = getHours(angle, previousHourType)
 
-        let hours12AndPm = !hours24 && modeRef.current === 'AM'
-
+        let hours12AndAm = !hours24 && modeRef.current === 'AM'
         let hourTypeFromOffset = getHourTypeFromOffset(x, y, circleSize)
         let hours24AndPM = hours24 && hourTypeFromOffset === hourTypes.pm
 
         // Avoiding the "24h"
         // Should be 12h for 12 hours and PM mode
-
-        if (hours12AndPm || hours24AndPM) {
+        if (!hours12AndAm || hours24AndPM) {
           pickedHours += 12
         }
         if (modeRef.current === 'AM' && pickedHours === 12) {


### PR DESCRIPTION
- [x] Resolves https://github.com/web-ridge/react-native-paper-dates/issues/226

@RichardLindhout Please give this a test before merging. It looks like there was an oversight `let hours12AndPm = !hours24 && modeRef.current === 'AM'` shouldn't be checking for `PM` if the `modeRef.current === 'AM'`. This was causing the reproducible bug provided in the issue.