### PR TITLE
Date input props

### DIFF
--- a/docusaurus/docs/date-picker/input-date-picker.md
+++ b/docusaurus/docs/date-picker/input-date-picker.md
@@ -53,7 +53,11 @@ The value used to populate the component.
 
 **onChange**  
 `Type: Function`  
-Event handler when the component changes.
+Callback event when the component date mask length matches the text input length.
+
+**onChangeText**  
+`Type: Function`  
+Callback event when the component text input changes.
 
 **inputMode (Required)**  
 `Type: String`  
@@ -78,5 +82,21 @@ Flag indicating if the the component should hide error styles along with the `he
 **onValidationError**  
 `Type: Function | undefined`  
 Callback used to return any error messages from the components validation.
+
+**saveLabelDisabled**  
+`Type: boolean | undefined`  
+Flag indicating if the save label should be disabled and unable to receive events. Defaults to `false`.
+
+**uppercase**  
+`Type: boolean | undefined`  
+Flag indicating if the text in the component should be uppercase. Defaults to `true`.
+
+**startYear**  
+`Type: number | undefined`  
+The start year when the component is rendered. Defaults to `1800`.
+
+**endYear**  
+`Type: number | undefined`  
+The end year when the component is rendered. Defaults to `2200`.
 
 * Other [react-native TextInput props](https://reactnative.dev/docs/textinput#props).*

--- a/docusaurus/docs/date-picker/input-date-picker.md
+++ b/docusaurus/docs/date-picker/input-date-picker.md
@@ -63,4 +63,20 @@ The type of input needed for the the picker component.
 `Type: 'flat' | 'outlined'`  
 See [react-native-paper text-input](https://callstack.github.io/react-native-paper/text-input.html#mode).
 
+**withDateFormatInLabel**
+`Type: boolean | undefined`  
+Flag indicating if the date format should be inside the components label.
+
+**hasError**  
+`Type: boolean | undefined`  
+Flag indicating if the the component should display error styles.
+
+**hideValidationErrors**  
+`Type: boolean | undefined`  
+Flag indicating if the the component should hide error styles along with the `helperText` component displaying the error message.
+
+**onValidationError**  
+`Type: Function | undefined`  
+Callback used to return any error messages from the components validation.
+
 * Other [react-native TextInput props](https://reactnative.dev/docs/textinput#props).*

--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -12,7 +12,7 @@ export type DatePickerInputProps = {
   withDateFormatInLabel?: boolean
   hideValidationErrors?: boolean
   hasError?: boolean
-  onValidationError?: ((error: string) => void) | undefined
+  onValidationError?: ((error: string | null) => void) | undefined
   calendarIcon?: string
   saveLabel?: string
 } & Omit<

--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -10,6 +10,9 @@ export type DatePickerInputProps = {
   validRange?: ValidRangeType | undefined
   withModal?: boolean
   withDateFormatInLabel?: boolean
+  hideValidationErrors?: boolean
+  hasError?: boolean
+  onValidationError?: ((error: string) => void) | undefined
   calendarIcon?: string
   saveLabel?: string
 } & Omit<

--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -15,6 +15,11 @@ export type DatePickerInputProps = {
   onValidationError?: ((error: string | null) => void) | undefined
   calendarIcon?: string
   saveLabel?: string
+  saveLabelDisabled?: boolean
+  uppercase?: boolean
+  startYear?: number
+  endYear?: number
+  onChangeText?: (text: string | undefined) => void
 } & Omit<
   React.ComponentProps<typeof TextInput>,
   'value' | 'onChange' | 'onChangeText'

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -42,7 +42,18 @@ function DatePickerInput(
           />
         ) : null
       }
-      modal={({ value, locale, inputMode, validRange, saveLabel }) =>
+      // eslint-disable-next-line react/no-unstable-nested-components
+      modal={({
+        value,
+        locale,
+        inputMode,
+        validRange,
+        saveLabel,
+        saveLabelDisabled,
+        uppercase,
+        startYear,
+        endYear,
+      }) =>
         withModal ? (
           <DatePickerModal
             date={value}
@@ -54,6 +65,10 @@ function DatePickerInput(
             dateMode={inputMode}
             validRange={validRange}
             saveLabel={saveLabel}
+            saveLabelDisabled={saveLabelDisabled || false}
+            uppercase={uppercase || true}
+            startYear={startYear || 1800}
+            endYear={endYear || 2200}
           />
         ) : null
       }

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -65,10 +65,10 @@ function DatePickerInput(
             dateMode={inputMode}
             validRange={validRange}
             saveLabel={saveLabel}
-            saveLabelDisabled={saveLabelDisabled || false}
-            uppercase={uppercase || true}
-            startYear={startYear || 1800}
-            endYear={endYear || 2200}
+            saveLabelDisabled={saveLabelDisabled ?? false}
+            uppercase={uppercase ?? true}
+            startYear={startYear ?? 1800}
+            endYear={endYear ?? 2200}
           />
         ) : null
       }

--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -73,7 +73,7 @@ function DatePickerInputWithoutModal(
               withDateFormatInLabel,
             })}
             value={formattedValue}
-            keyboardType={'number-pad'}
+            keyboardType={rest.keyboardType ?? 'number-pad'}
             mask={inputFormat}
             onChangeText={onDateInputChangeText}
             onChange={(e) => onChangeText && onChangeText(e.nativeEvent.text)}

--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -22,6 +22,11 @@ function DatePickerInputWithoutModal(
     modal,
     inputButtons,
     saveLabel,
+    saveLabelDisabled,
+    uppercase,
+    startYear,
+    endYear,
+    onChangeText,
     ...rest
   }: DatePickerInputProps & {
     modal?: (params: {
@@ -30,13 +35,22 @@ function DatePickerInputWithoutModal(
       inputMode: DatePickerInputProps['inputMode']
       validRange: DatePickerInputProps['validRange']
       saveLabel: DatePickerInputProps['saveLabel']
+      saveLabelDisabled: DatePickerInputProps['saveLabelDisabled']
+      uppercase: DatePickerInputProps['uppercase']
+      startYear: DatePickerInputProps['startYear']
+      endYear: DatePickerInputProps['endYear']
     }) => any
     inputButtons?: any
   },
   ref: any
 ) {
   const theme = useTheme()
-  const { formattedValue, inputFormat, onChangeText, error } = useDateInput({
+  const {
+    formattedValue,
+    inputFormat,
+    onChangeText: onDateInputChangeText,
+    error,
+  } = useDateInput({
     locale,
     value,
     validRange,
@@ -61,7 +75,8 @@ function DatePickerInputWithoutModal(
             value={formattedValue}
             keyboardType={'number-pad'}
             mask={inputFormat}
-            onChangeText={onChangeText}
+            onChangeText={onDateInputChangeText}
+            onChange={(e) => onChangeText && onChangeText(e.nativeEvent.text)}
             keyboardAppearance={theme.dark ? 'dark' : 'default'}
             error={(!!error && !hideValidationErrors) || !!hasError}
             style={[styles.input, style]}
@@ -69,12 +84,22 @@ function DatePickerInputWithoutModal(
           {inputButtons}
         </View>
         {error && !hideValidationErrors ? (
-          <HelperText style={styles.helperText} type="error" visible={!!error}>
+          <HelperText type="error" visible={!!error}>
             {error}
           </HelperText>
         ) : null}
       </View>
-      {modal?.({ value, locale, inputMode, validRange, saveLabel })}
+      {modal?.({
+        value,
+        locale,
+        inputMode,
+        validRange,
+        saveLabel,
+        saveLabelDisabled,
+        uppercase,
+        startYear,
+        endYear,
+      })}
     </>
   )
 }
@@ -106,9 +131,6 @@ const styles = StyleSheet.create({
   },
   input: {
     flexGrow: 1,
-  },
-  helperText: {
-    // flex: 1,
   },
 })
 export default React.forwardRef(DatePickerInputWithoutModal)

--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -16,6 +16,9 @@ function DatePickerInputWithoutModal(
     validRange,
     inputMode,
     withDateFormatInLabel = true,
+    hasError,
+    hideValidationErrors,
+    onValidationError,
     modal,
     inputButtons,
     saveLabel,
@@ -39,6 +42,7 @@ function DatePickerInputWithoutModal(
     validRange,
     inputMode,
     onChange,
+    onValidationError,
   })
 
   return (
@@ -56,16 +60,15 @@ function DatePickerInputWithoutModal(
             })}
             value={formattedValue}
             keyboardType={'number-pad'}
-            placeholder={inputFormat}
             mask={inputFormat}
             onChangeText={onChangeText}
             keyboardAppearance={theme.dark ? 'dark' : 'default'}
-            error={!!error}
+            error={(!!error && !hideValidationErrors) || !!hasError}
             style={[styles.input, style]}
           />
           {inputButtons}
         </View>
-        {error ? (
+        {error && !hideValidationErrors ? (
           <HelperText style={styles.helperText} type="error" visible={!!error}>
             {error}
           </HelperText>

--- a/src/Date/inputUtils.ts
+++ b/src/Date/inputUtils.ts
@@ -16,7 +16,7 @@ export default function useDateInput({
   value: Date | undefined
   validRange: ValidRangeType | undefined
   inputMode: 'start' | 'end'
-  onValidationError?: ((error: string) => void) | undefined
+  onValidationError?: ((error: string | null) => void) | undefined
 }) {
   const { isDisabled, isWithinValidRange, validStart, validEnd } =
     useRangeChecker(validRange)
@@ -43,7 +43,7 @@ export default function useDateInput({
         () => 'notAccordingToDateFormat'
       )(inputFormat)
       setError(inputError)
-      onValidationError(inputError)
+      onValidationError && onValidationError(inputError)
       return
     }
 
@@ -55,7 +55,7 @@ export default function useDateInput({
     if (isDisabled(finalDate)) {
       const inputError = getTranslation(locale, 'dateIsDisabled')
       setError(inputError)
-      onValidationError(inputError)
+      onValidationError && onValidationError(inputError)
       return
     }
     if (!isWithinValidRange(finalDate)) {
@@ -86,12 +86,12 @@ export default function useDateInput({
             ]
       const inputError = errors.filter((n) => n).join(' ')
       setError(errors.filter((n) => n).join(' '))
-      onValidationError(inputError)
+      onValidationError && onValidationError(inputError)
       return
     }
 
     setError(null)
-    onValidationError(null)
+    onValidationError && onValidationError(null)
     if (inputMode === 'end') {
       onChange(finalDate)
     } else {

--- a/src/Date/inputUtils.ts
+++ b/src/Date/inputUtils.ts
@@ -23,7 +23,7 @@ export default function useDateInput({
   const [error, setError] = React.useState<null | string>(null)
   const formatter = useInputFormatter({ locale })
   const inputFormat = useInputFormat({ formatter, locale })
-  const formattedValue = value !== null ? formatter.format(value) : ''
+  const formattedValue = value ? formatter.format(value) : ''
   const onChangeText = (date: string) => {
     const dayIndex = inputFormat.indexOf('DD')
     const monthIndex = inputFormat.indexOf('MM')

--- a/src/Date/inputUtils.ts
+++ b/src/Date/inputUtils.ts
@@ -9,12 +9,14 @@ export default function useDateInput({
   validRange,
   inputMode,
   onChange,
+  onValidationError,
 }: {
   onChange: (d: Date) => void
   locale: undefined | string
   value: Date | undefined
   validRange: ValidRangeType | undefined
   inputMode: 'start' | 'end'
+  onValidationError?: ((error: string) => void) | undefined
 }) {
   const { isDisabled, isWithinValidRange, validStart, validEnd } =
     useRangeChecker(validRange)
@@ -35,13 +37,13 @@ export default function useDateInput({
     const month = Number(date.slice(monthIndex, monthIndex + 2))
 
     if (Number.isNaN(day) || Number.isNaN(year) || Number.isNaN(month)) {
-      setError(
-        getTranslation(
-          locale,
-          'notAccordingToDateFormat',
-          () => 'notAccordingToDateFormat'
-        )(inputFormat)
-      )
+      const inputError = getTranslation(
+        locale,
+        'notAccordingToDateFormat',
+        () => 'notAccordingToDateFormat'
+      )(inputFormat)
+      setError(inputError)
+      onValidationError(inputError)
       return
     }
 
@@ -51,7 +53,9 @@ export default function useDateInput({
         : new Date(year, month - 1, day)
 
     if (isDisabled(finalDate)) {
-      setError(getTranslation(locale, 'dateIsDisabled'))
+      const inputError = getTranslation(locale, 'dateIsDisabled')
+      setError(inputError)
+      onValidationError(inputError)
       return
     }
     if (!isWithinValidRange(finalDate)) {
@@ -80,11 +84,14 @@ export default function useDateInput({
                   )(formatter.format(validEnd))
                 : '',
             ]
+      const inputError = errors.filter((n) => n).join(' ')
       setError(errors.filter((n) => n).join(' '))
+      onValidationError(inputError)
       return
     }
 
     setError(null)
+    onValidationError(null)
     if (inputMode === 'end') {
       onChange(finalDate)
     } else {

--- a/src/TextInputMask.tsx
+++ b/src/TextInputMask.tsx
@@ -69,6 +69,7 @@ function enhanceTextWithMask(
 function TextInputWithMask(
   {
     onChangeText,
+    onChange,
     value,
     mask,
     ...rest
@@ -101,6 +102,9 @@ function TextInputWithMask(
       {...rest}
       value={controlledValue}
       onChangeText={onInnerChange}
+      onChange={(e) => {
+        onChange && onChange(e)
+      }}
       onBlur={onInnerBlur}
     />
   )

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -3593,6 +3593,7 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
                 maxFontSizeMultiplier={1.5}
                 multiline={false}
                 onBlur={[Function]}
+                onChange={[Function]}
                 onChangeText={[Function]}
                 onFocus={[Function]}
                 onSubmitEditing={[Function]}

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -176,6 +176,7 @@ exports[`renders CalendarEdit 1`] = `
             maxFontSizeMultiplier={1.5}
             multiline={false}
             onBlur={[Function]}
+            onChange={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
             onSubmitEditing={[Function]}

--- a/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
@@ -170,6 +170,7 @@ exports[`renders DatePickerInput 1`] = `
             maxFontSizeMultiplier={1.5}
             multiline={false}
             onBlur={[Function]}
+            onChange={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
             placeholder=" "

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -169,6 +169,7 @@ exports[`renders DatePickerInput 1`] = `
           maxFontSizeMultiplier={1.5}
           multiline={false}
           onBlur={[Function]}
+          onChange={[Function]}
           onChangeText={[Function]}
           onFocus={[Function]}
           placeholder=" "


### PR DESCRIPTION
### Motivation
The `DatePickerInput` does not give the flexibility to roll out your own validation (ex. if a user selected date of birth is older than 18 years) which could result in two `helperText` errors being shown under the `DatePickerInput`.

This PR introduces a few new props `hideValidationErrors`, `hasError`, and `onValidationError`, etc in order to provide the ability to ingest the internal validation errors from the component, hide the components error styles, and give the developer the option of rolling out there own validation.

_The developer docs are updated as well to have all the new props along with some other missing props._