### PR TITLE
24 hour bug

### DIFF
--- a/src/Time/AnalogClock.tsx
+++ b/src/Time/AnalogClock.tsx
@@ -43,7 +43,7 @@ function AnalogClock({
   const theme = useTheme()
   const { mode } = React.useContext(DisplayModeContext)
   // used to make pointer shorter if hours are selected and above 12
-  const shortPointer = (hours === 0 || hours > 12) && is24Hour
+  const shortPointer = hours >= 12 && is24Hour
   const clockRef = React.useRef<View | null>(null)
   // Hooks are nice, sometimes... :-)..
   // We need the latest values, since the onPointerMove uses a closure to the function
@@ -74,15 +74,16 @@ function AnalogClock({
         if (hours12AndPm || hours24AndPM) {
           pickedHours += 12
         }
-        if (modeRef.current === 'AM' && pickedHours === 12) {
+        if ((modeRef.current === 'AM' || hours24) && pickedHours === 12) {
           pickedHours = 0
         }
 
-        if (
-          (!hours24 && modeRef.current === 'AM' && pickedHours === 12) ||
-          pickedHours === 24
-        ) {
+        if (!hours24 && modeRef.current === 'AM' && pickedHours === 12) {
           pickedHours = 0
+        }
+
+        if (pickedHours === 24) {
+          pickedHours = 12
         }
 
         if (hoursRef.current !== pickedHours || final) {

--- a/src/Time/AnalogClockHours.tsx
+++ b/src/Time/AnalogClockHours.tsx
@@ -3,7 +3,6 @@ import { View, StyleSheet } from 'react-native'
 import { Text } from 'react-native-paper'
 import { circleSize } from './timeUtils'
 import { useTextColorOnPrimary } from '../utils'
-import { DisplayModeContext } from './TimePicker'
 
 function AnalogClockHours({
   is24Hour,
@@ -12,7 +11,6 @@ function AnalogClockHours({
   is24Hour: boolean
   hours: number
 }) {
-  const { mode } = React.useContext(DisplayModeContext)
   const outerRange = getHourNumbers(false, circleSize, 12, 12)
   const innerRange = getHourNumbers(true, circleSize, 12, 12)
   const color = useTextColorOnPrimary()

--- a/src/Time/AnalogClockHours.tsx
+++ b/src/Time/AnalogClockHours.tsx
@@ -35,6 +35,7 @@ function AnalogClockHours({
             {/* Display 00 instead of 12 for AM hours */}
             <Text
               style={
+                (!is24Hour && i + 1 === hours) ||
                 (hours === i + 1 && hours !== 12) ||
                 (i + 1 === 12 && hours === 0)
                   ? { color }
@@ -43,7 +44,7 @@ function AnalogClockHours({
               variant="bodyLarge"
               selectable={false}
             >
-              {(mode === 'AM' || is24Hour) && i + 1 === 12 ? '00' : i + 1}
+              {is24Hour && i + 1 === 12 ? '00' : i + 1}
             </Text>
           </View>
         </View>

--- a/src/Time/AnalogClockHours.tsx
+++ b/src/Time/AnalogClockHours.tsx
@@ -34,11 +34,16 @@ function AnalogClockHours({
           <View style={styles.outerHourInner}>
             {/* Display 00 instead of 12 for AM hours */}
             <Text
-              style={hours === i + 1 ? { color } : null}
+              style={
+                (hours === i + 1 && hours !== 12) ||
+                (i + 1 === 12 && hours === 0)
+                  ? { color }
+                  : null
+              }
               variant="bodyLarge"
               selectable={false}
             >
-              {mode === 'AM' && is24Hour && i + 1 === 12 ? '00' : i + 1}
+              {(mode === 'AM' || is24Hour) && i + 1 === 12 ? '00' : i + 1}
             </Text>
           </View>
         </View>
@@ -60,13 +65,13 @@ function AnalogClockHours({
                 <Text
                   selectable={false}
                   style={[
-                    i + 13 === hours || (i + 13 === 24 && hours === 0)
+                    i + 13 === hours || (i + 13 === 24 && hours === 12)
                       ? { color }
                       : null,
                   ]}
                   variant="bodyLarge"
                 >
-                  {i + 13 === 24 ? '00' : i + 13}
+                  {i + 13 === 24 ? '12' : i + 13}
                 </Text>
               </View>
             </View>

--- a/src/__tests__/Time/__snapshots__/AnalogClock.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AnalogClock.test.tsx.snap
@@ -788,11 +788,13 @@ exports[`renders AnalogClock 1`] = `
                 {
                   "writingDirection": "ltr",
                 },
-                null,
+                {
+                  "color": "rgba(255, 255, 255, 1)",
+                },
               ]
             }
           >
-            00
+            12
           </Text>
         </View>
       </View>

--- a/src/__tests__/Time/__snapshots__/AnalogClock.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AnalogClock.test.tsx.snap
@@ -788,13 +788,11 @@ exports[`renders AnalogClock 1`] = `
                 {
                   "writingDirection": "ltr",
                 },
-                {
-                  "color": "rgba(255, 255, 255, 1)",
-                },
+                null,
               ]
             }
           >
-            12
+            00
           </Text>
         </View>
       </View>

--- a/src/__tests__/Time/__snapshots__/AnalogClockHours.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AnalogClockHours.test.tsx.snap
@@ -654,9 +654,7 @@ exports[`renders AnalogClockHours 1`] = `
             {
               "writingDirection": "ltr",
             },
-            {
-              "color": "rgba(255, 255, 255, 1)",
-            },
+            null,
           ]
         }
       >
@@ -1339,12 +1337,14 @@ exports[`renders AnalogClockHours 1`] = `
               "writingDirection": "ltr",
             },
             [
-              null,
+              {
+                "color": "rgba(255, 255, 255, 1)",
+              },
             ],
           ]
         }
       >
-        00
+        12
       </Text>
     </View>
   </View>,


### PR DESCRIPTION
### Motivation

- [x] Ultimately addresses https://github.com/web-ridge/react-native-paper-dates/issues/239

## Remarks

1. As part of the ticket above I noticed 00 is appearing twice in the clock. Its correct appearance should be as follows with "00" and "12". That is addressed as part of this.
![image](https://user-images.githubusercontent.com/7604441/213877789-99d195c0-80b3-41f4-9c1f-788631699359.png)

2. "00" was also appearing in the 12 hour clock which isn't standard. According to the [material 3 docs](https://m3.material.io/components/time-pickers/guidelines#e72059b2-d772-456b-bbc7-bd8aeed0144f) it should be 12 instead. This is addressed as part of this.
![image](https://user-images.githubusercontent.com/7604441/213877861-0d7120a4-7d13-4eec-bcd3-2539c74dbb1b.png)

@RichardLindhout  Please test and verify existing functionality still behaves as expected.