### PR TITLE
Pass disabled to icon button.

### DIFF
--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -38,6 +38,7 @@ function DatePickerInput(
             size={24}
             style={styles.calendarButton}
             icon={calendarIcon}
+            disabled={rest.disabled}
             onPress={() => setVisible(true)}
           />
         ) : null


### PR DESCRIPTION
### Motivation
When the `disabled` prop is passed to the `DatePickerInput` the `IconButton` is not also disabled. This pull request passes the disabled prop along to the `IconButton`, so that the entire component will become disabled is specified.