### PR TITLE
Fix overlapping attributes.

### DIFF
--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -23,5 +23,5 @@ export type DatePickerInputProps = {
   inputEnabled?: boolean
 } & Omit<
   React.ComponentProps<typeof TextInput>,
-  'value' | 'onChange' | 'onChangeText'
+  'value' | 'onChange' | 'onChangeText' | 'inputMode'
 >


### PR DESCRIPTION
### Motivation
Addresses typescript issues that will arise when we update to react native 71 and Expo 48. Confirmed it still has backward compatibility, but feel free to verify.

More details are described in this [discussion](https://github.com/web-ridge/react-native-paper-dates/discussions/261). In short it looks like once we update the `inputMode` props overlap causing the entire type to become `never`.