### PR TITLE
Fix the allowEditing prop which was being accidentally ignored

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -306,6 +306,8 @@ function App() {
         // animationType="slide" // optional, default is slide on ios/android and none on web
         // startYear={2000} // optional, default is 1800
         // endYear={2100} // optional, default is 2200
+        // allowEditing={false} // optional, default is true
+        // inputEnabled={false} // optional, default is true
       />
 
       <DatePickerModal
@@ -327,6 +329,8 @@ function App() {
         // animationType="slide" // optional, default is 'slide' on ios/android and 'none' on web
         // startYear={2000} // optional, default is 1800
         // endYear={2100} // optional, default is 2200
+        // allowEditing={false} // optional, default is true
+        // inputEnabled={false} // optional, default is true
       />
 
       <DatePickerModal

--- a/src/Date/DatePickerModalContent.tsx
+++ b/src/Date/DatePickerModalContent.tsx
@@ -165,7 +165,7 @@ export function DatePickerModalContent(
           locale={locale}
           editIcon={props?.editIcon}
           calendarIcon={props.calendarIcon}
-          allowEditing={props.allowEditing || true}
+          allowEditing={props.allowEditing ?? true}
         />
       </DatePickerModalHeaderBackground>
       <AnimatedCrossView

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -28,7 +28,6 @@ export interface HeaderContentProps extends HeaderPickProps {
   collapsed: boolean
   onToggle: () => any
   locale: string | undefined
-  inputDate?: boolean
 }
 
 function getLabel(
@@ -62,7 +61,6 @@ export default function DatePickerModalContentHeader(
     uppercase,
     editIcon,
     calendarIcon,
-    inputDate,
     allowEditing,
   } = props
   const theme = useTheme()
@@ -70,7 +68,7 @@ export default function DatePickerModalContentHeader(
 
   const color = useHeaderTextColor()
 
-  const isAllowEditing = allowEditing && mode !== 'multiple' && inputDate !== undefined
+  const isEditingEnabled = allowEditing && mode !== 'multiple'
 
   const supportingTextColor = theme.isV3 ? theme.colors.onSurfaceVariant : color
 
@@ -103,7 +101,7 @@ export default function DatePickerModalContentHeader(
         </View>
       </View>
       <View style={styles.fill} />
-      {isAllowEditing ? (
+      {isEditingEnabled ? (
         <IconButton
           icon={
             collapsed

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -488,6 +488,7 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
           onScrollEndDrag={[Function]}
           removeClippedSubviews={false}
           renderItem={[Function]}
+          renderScrollComponent={[Function]}
           scrollEventThrottle={50}
           stickyHeaderIndices={[]}
           style={

--- a/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
@@ -463,6 +463,7 @@ exports[`renders Calendar 1`] = `
       onScrollEndDrag={[Function]}
       removeClippedSubviews={false}
       renderItem={[Function]}
+      renderScrollComponent={[Function]}
       scrollEventThrottle={50}
       stickyHeaderIndices={[]}
       style={

--- a/src/__tests__/Date/__snapshots__/YearPicker.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/YearPicker.test.tsx.snap
@@ -444,6 +444,7 @@ exports[`renders YearPicker 1`] = `
     onScrollEndDrag={[Function]}
     removeClippedSubviews={false}
     renderItem={[Function]}
+    renderScrollComponent={[Function]}
     scrollEventThrottle={50}
     stickyHeaderIndices={[]}
     style={


### PR DESCRIPTION
This PR fixes some issues related to the `allowEditing` prop that was recently added to the Date Picker Header:

1. Prevents it from being always `true` regardless the value that was actually passed.
2. Uses the `allowEditing` prop correctly to decide if the edit button should be displayed or not. Before, an unused `inputDate` prop, which was always undefined, was making the edit button not to be rendered at all, regardless of the props being passed to the component for this purpose.