### PR TITLE
Fix: date picker modal is taking the whole screen even the safe area

### DIFF
--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -67,10 +67,9 @@ export function DatePickerModal(
     <View style={[StyleSheet.absoluteFill]} pointerEvents="box-none">
       <Modal
         animationType={animationTypeCalculated}
-        transparent={true}
         visible={visible}
         onRequestClose={rest.onDismiss}
-        presentationStyle="overFullScreen"
+        presentationStyle="pageSheet"
         supportedOrientations={supportedOrientations}
         //@ts-ignore
         statusBarTranslucent={true}

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -70,7 +70,8 @@ export default function DatePickerModalContentHeader(
 
   const color = useHeaderTextColor()
 
-  const isAllowEditing = allowEditing && mode !== 'multiple' && inputDate !== undefined
+  const isAllowEditing =
+    allowEditing && mode !== 'multiple' && inputDate !== undefined
 
   const supportingTextColor = theme.isV3 ? theme.colors.onSurfaceVariant : color
 

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -488,6 +488,7 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
           onScrollEndDrag={[Function]}
           removeClippedSubviews={false}
           renderItem={[Function]}
+          renderScrollComponent={[Function]}
           scrollEventThrottle={50}
           stickyHeaderIndices={[]}
           style={

--- a/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
@@ -463,6 +463,7 @@ exports[`renders Calendar 1`] = `
       onScrollEndDrag={[Function]}
       removeClippedSubviews={false}
       renderItem={[Function]}
+      renderScrollComponent={[Function]}
       scrollEventThrottle={50}
       stickyHeaderIndices={[]}
       style={

--- a/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
@@ -384,7 +384,7 @@ exports[`renders DatePickerInput 1`] = `
       animationType="slide"
       hardwareAccelerated={false}
       onRequestClose={[Function]}
-      presentationStyle="overFullScreen"
+      presentationStyle="pageSheet"
       statusBarTranslucent={true}
       supportedOrientations={
         [
@@ -395,7 +395,6 @@ exports[`renders DatePickerInput 1`] = `
           "landscape-right",
         ]
       }
-      transparent={true}
       visible={false}
     />
   </View>,

--- a/src/__tests__/Date/__snapshots__/YearPicker.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/YearPicker.test.tsx.snap
@@ -444,6 +444,7 @@ exports[`renders YearPicker 1`] = `
     onScrollEndDrag={[Function]}
     removeClippedSubviews={false}
     renderItem={[Function]}
+    renderScrollComponent={[Function]}
     scrollEventThrottle={50}
     stickyHeaderIndices={[]}
     style={


### PR DESCRIPTION
# Description

Date Picker Modal is taking the whole screen even the safe area not able to click the close or save button. Now it is fixed.