### PR TITLE
Fix date range gap.

### DIFF
--- a/src/Date/DayRange.tsx
+++ b/src/Date/DayRange.tsx
@@ -35,7 +35,7 @@ function DayRange({
           <>
             <View
               style={[
-                styles.flex1,
+                styles.rightCrop,
                 rightCrop
                   ? {
                       backgroundColor: selectColor,
@@ -89,6 +89,9 @@ const styles = StyleSheet.create({
   },
   rangeRoot: {
     flexDirection: 'row',
+  },
+  rightCrop: {
+    flexBasis: 5,
   },
 })
 


### PR DESCRIPTION
### Motivation

- [x] Fixes https://github.com/web-ridge/react-native-paper-dates/issues/271 and https://github.com/web-ridge/react-native-paper-dates/issues/281. @RichardLindhout I'm not 100% sure if `flex-basis` is being used properly here, but it did achieve the desired effect. I'm not sure if this will cause any unplanned issues, but maybe you have an idea.

Before
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-27 at 19 36 03](https://user-images.githubusercontent.com/7604441/228090794-0ab89af6-1ca0-486d-b166-f468dc204e9d.png)

After
![simulator_screenshot_73DFBB5C-6728-44DA-8F1E-7D04EBA2A39C](https://user-images.githubusercontent.com/7604441/228090834-664f42e5-fdab-442c-96bc-d01317002f67.png)

Note - There are no guidelines on selecting a range to itself, but this is a potential existing style bug, that I noticed while playing around trying to fix this issue. @RichardLindhout Let me know your thoughts on this.

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-27 at 19 37 33](https://user-images.githubusercontent.com/7604441/228090993-efd44f26-3f58-4ac2-acea-d86b807005e8.png)

