### PR TITLE
Fix for passing dot as splitcharacter to RegExp constructor

### DIFF
--- a/src/TextInputMask.tsx
+++ b/src/TextInputMask.tsx
@@ -7,6 +7,10 @@ function detectCharacter(mask: string): string {
   return c || ''
 }
 
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function TextInputWithMask(
   {
     onChangeText,
@@ -40,7 +44,7 @@ function TextInputWithMask(
     )
     const replaceValue = format.match(/\W/)
     const replace = `$1${splitCharacter}$2${splitCharacter}$3$4`.replace(
-      new RegExp(splitCharacter, 'g'),
+      new RegExp(escapeForRegExp(splitCharacter), 'g'),
       (replaceValue ?? '') as string
     )
 


### PR DESCRIPTION
**Issue:**

When the locale of the DatePickerInput component is set to "de" (German), the functionality to add an automatic date separator ("." in the case of the German locale) is broken. Instead of appending a dot to the first two characters entered, the input gets changed to a single dot. Subsequently, any numbers entered are concatenated without the proper separator.

**Solution:**

I found the usage of the `RegExp` constructor to create regular expressions. One of the supported date separator is `.` (dd.mm.yyyy). The `dot` character is a `metacharacter` in regular expressions which needs to be escaped if it is being passed into the `RegExp` constructor. In this code block, it was not escaped. Hence the code 

```JS
new RegExp('.', 'g')
```

yielded a different regex than the expected one. 

Fixes [DatePickerInput component breaks automatic date separator when setting locale to "de"](https://github.com/web-ridge/react-native-paper-dates/issues/296)