### PR TITLE
style: removed unnecessary code

### DIFF
--- a/src/Date/DatePickerModalHeader.tsx
+++ b/src/Date/DatePickerModalHeader.tsx
@@ -69,7 +69,6 @@ const styles = StyleSheet.create({
   animated: {
     elevation: 4,
   },
-
   header: {
     height: 75,
     alignItems: 'center',


### PR DESCRIPTION
Trying to find a solution for the issue #309, I found this unnecesary code.
The `fill`style was not using and the prop `color` was deprecated and now is `textColor`.