### PR TITLE
fix alignment calendar icon

### DIFF
--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -21,7 +21,6 @@ export type DatePickerInputProps = {
   endYear?: number
   onChangeText?: (text: string | undefined) => void
   inputEnabled?: boolean
-  inputButton?: React.ReactNode
 } & Omit<
   React.ComponentProps<typeof TextInput>,
   'value' | 'onChange' | 'onChangeText' | 'inputMode'

--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -21,6 +21,7 @@ export type DatePickerInputProps = {
   endYear?: number
   onChangeText?: (text: string | undefined) => void
   inputEnabled?: boolean
+  inputButton?: React.ReactNode
 } & Omit<
   React.ComponentProps<typeof TextInput>,
   'value' | 'onChange' | 'onChangeText' | 'inputMode'

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { IconButton } from 'react-native-paper'
+import { TextInput } from 'react-native-paper'
 import DatePickerModal from './DatePickerModal'
 import { useLatest } from '../utils'
 import type { DatePickerInputProps } from './DatePickerInput.shared'
@@ -33,7 +33,7 @@ function DatePickerInput(
       {...rest}
       inputButton={
         withModal ? (
-          <IconButton
+          <TextInput.Icon
             size={24}
             icon={calendarIcon}
             disabled={rest.disabled}

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
 import { IconButton } from 'react-native-paper'
-import { StyleSheet } from 'react-native'
 import DatePickerModal from './DatePickerModal'
 import { useLatest } from '../utils'
 import type { DatePickerInputProps } from './DatePickerInput.shared'
@@ -32,11 +31,10 @@ function DatePickerInput(
     <DatePickerInputWithoutModal
       ref={ref}
       {...rest}
-      inputButtons={
+      inputButton={
         withModal ? (
           <IconButton
             size={24}
-            style={styles.calendarButton}
             icon={calendarIcon}
             disabled={rest.disabled}
             onPress={() => setVisible(true)}
@@ -78,9 +76,5 @@ function DatePickerInput(
     />
   )
 }
-
-const styles = StyleSheet.create({
-  calendarButton: { position: 'absolute', right: 0, zIndex: 10 },
-})
 
 export default React.forwardRef(DatePickerInput)

--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -20,7 +20,7 @@ function DatePickerInputWithoutModal(
     hideValidationErrors,
     onValidationError,
     modal,
-    inputButtons,
+    inputButton,
     saveLabel,
     saveLabelDisabled,
     uppercase,
@@ -76,6 +76,7 @@ function DatePickerInputWithoutModal(
       <View style={styles.root}>
         <View style={styles.inputContainer}>
           <TextInputWithMask
+            inputButton={inputButton}
             {...rest}
             ref={ref}
             label={getLabel({
@@ -94,7 +95,7 @@ function DatePickerInputWithoutModal(
             error={(!!error && !hideValidationErrors) || !!hasError}
             style={[styles.input, style]}
           />
-          {inputButtons}
+          {/* {inputButtons} */}
         </View>
         {error && !hideValidationErrors ? (
           <HelperText type="error" visible={!!error}>
@@ -136,6 +137,8 @@ function getLabel({
 const styles = StyleSheet.create({
   root: {
     flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
   },
   inputContainer: {
     flexGrow: 1,

--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -42,7 +42,7 @@ function DatePickerInputWithoutModal(
       endYear: DatePickerInputProps['endYear']
       inputEnabled: DatePickerInputProps['inputEnabled']
     }) => any
-    inputButtons?: any
+    inputButton?: React.ReactNode
   },
   ref: any
 ) {
@@ -76,7 +76,6 @@ function DatePickerInputWithoutModal(
       <View style={styles.root}>
         <View style={styles.inputContainer}>
           <TextInputWithMask
-            inputButton={inputButton}
             {...rest}
             ref={ref}
             label={getLabel({
@@ -94,6 +93,7 @@ function DatePickerInputWithoutModal(
             keyboardAppearance={theme.dark ? 'dark' : 'default'}
             error={(!!error && !hideValidationErrors) || !!hasError}
             style={[styles.input, style]}
+            inputButton={inputButton}
           />
         </View>
         {error && !hideValidationErrors ? (

--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -95,7 +95,6 @@ function DatePickerInputWithoutModal(
             error={(!!error && !hideValidationErrors) || !!hasError}
             style={[styles.input, style]}
           />
-          {/* {inputButtons} */}
         </View>
         {error && !hideValidationErrors ? (
           <HelperText type="error" visible={!!error}>

--- a/src/TextInputMask.tsx
+++ b/src/TextInputMask.tsx
@@ -13,13 +13,18 @@ function escapeForRegExp(value: string): string {
 
 function TextInputWithMask(
   {
+    inputButton,
     onChangeText,
     onChange,
     value,
     mask,
     disabled,
     ...rest
-  }: React.ComponentProps<typeof TextInput> & { mask: string; value: string },
+  }: React.ComponentProps<typeof TextInput> & {
+    mask: string
+    value: string
+    inputButton: React.ReactNode
+  },
   ref: any
 ) {
   const [controlledValue, setControlledValue] = React.useState<string>(
@@ -69,17 +74,20 @@ function TextInputWithMask(
   }, [value])
 
   return (
-    <TextInput
-      ref={ref}
-      {...rest}
-      disabled={disabled}
-      value={controlledValue}
-      onChangeText={onInnerChange}
-      onChange={(e) => {
-        onChange && onChange(e)
-      }}
-      maxLength={10}
-    />
+    <>
+      <TextInput
+        ref={ref}
+        {...rest}
+        disabled={disabled}
+        value={controlledValue}
+        onChangeText={onInnerChange}
+        onChange={(e) => {
+          onChange && onChange(e)
+        }}
+        maxLength={10}
+        right={<TextInput.Icon icon={() => inputButton} />}
+      />
+    </>
   )
 }
 

--- a/src/TextInputMask.tsx
+++ b/src/TextInputMask.tsx
@@ -85,7 +85,7 @@ function TextInputWithMask(
           onChange && onChange(e)
         }}
         maxLength={10}
-        right={<TextInput.Icon icon={() => inputButton} />}
+        right={inputButton}
       />
     </>
   )

--- a/src/TextInputMask.tsx
+++ b/src/TextInputMask.tsx
@@ -74,20 +74,18 @@ function TextInputWithMask(
   }, [value])
 
   return (
-    <>
-      <TextInput
-        ref={ref}
-        {...rest}
-        disabled={disabled}
-        value={controlledValue}
-        onChangeText={onInnerChange}
-        onChange={(e) => {
-          onChange && onChange(e)
-        }}
-        maxLength={10}
-        right={inputButton}
-      />
-    </>
+    <TextInput
+      ref={ref}
+      {...rest}
+      disabled={disabled}
+      value={controlledValue}
+      onChangeText={onInnerChange}
+      onChange={(e) => {
+        onChange && onChange(e)
+      }}
+      maxLength={10}
+      right={inputButton}
+    />
   )
 }
 

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -3859,7 +3859,9 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
       <View
         style={
           {
+            "alignItems": "flex-start",
             "flexGrow": 1,
+            "justifyContent": "center",
           }
         }
       >

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -11,7 +11,9 @@ exports[`renders CalendarEdit 1`] = `
   <View
     style={
       {
+        "alignItems": "flex-start",
         "flexGrow": 1,
+        "justifyContent": "center",
       }
     }
   >

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`renders DatePickerInput 1`] = `
 <View
   style={
     {
+      "alignItems": "flex-start",
       "flexGrow": 1,
+      "justifyContent": "center",
     }
   }
 >


### PR DESCRIPTION
Fix #298.

## ⬇️ ⬇️ ⬇️ Updated read below ⬇️ ⬇️ ⬇️  ⚠️ 

@RichardLindhout @iM-GeeKy 
I have changed different parts but the most important and the main problem for the alignment was the position absolute for the icon when you have in `react-native-paper` the option to add directly the icon in the right side and centered of the TextInput. Using the way of `react-native-paper`  will be centered by default

![image](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/3dcac579-bf55-4aba-bf51-620535a9fe95)

Here I attach a gif showing the currently position and will see a little movement (to the left and top)
This is because I changed between branchs to show the differences and is minimal and for that maybe it's more visible show it in this way:

![fixed problem calendar](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/b0d1f48e-745d-4b07-9dda-9e414a65d055).

I did and tested in Linux.  I tried to test in Windows but [you have another problem there](https://github.com/web-ridge/react-native-paper-dates/issues/314).
If someone can test, will be great.

---

# Updated ⚠️ 

Now the alignment is better.
I kept the same structure that you are using but I have replaced `IconButton`:

![image](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/d0a44fed-2ba7-4e7b-a3ab-6ae49b0280e8)

And now using like this:

![image](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/fdb049db-0a01-4128-8201-491f2e80a6bf)

The alignment is perfect!.

![alignment perfect](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/1b8bdb32-e408-408b-879e-3b104cb67e96)
