### PR TITLE
Fixed Datepicker modal jump when is opened

### DIFF
--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -15,8 +15,6 @@ import DatePickerModalContent, {
   DatePickerModalContentRangeProps,
   DatePickerModalContentSingleProps,
 } from './DatePickerModalContent'
-import { useHeaderBackgroundColor, useHeaderColorIsLight } from '../utils'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface DatePickerModalProps {
   visible: boolean
@@ -61,10 +59,6 @@ export function DatePickerModal(
       default: 'slide',
     })
 
-  const isLight = useHeaderColorIsLight()
-  const headerBackgroundColor = useHeaderBackgroundColor()
-  const insets = useSafeAreaInsets()
-
   return (
     <View style={[StyleSheet.absoluteFill]} pointerEvents="box-none">
       <Modal
@@ -98,18 +92,12 @@ export function DatePickerModal(
                 dimensions.width > 650 ? styles.modalContentBig : null,
               ]}
             >
-              {disableStatusBar ? null : (
-                <StatusBar
-                  translucent={true}
-                  barStyle={isLight ? 'dark-content' : 'light-content'}
-                />
-              )}
               {disableStatusBarPadding ? null : (
                 <View
                   style={[
                     {
-                      height: insets.top,
-                      backgroundColor: headerBackgroundColor,
+                      height: StatusBar.currentHeight,
+                      backgroundColor: theme.colors.primary,
                     },
                   ]}
                 />

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -14,6 +14,7 @@ import DatePickerModalContent, {
   DatePickerModalContentRangeProps,
   DatePickerModalContentSingleProps,
 } from './DatePickerModalContent'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface DatePickerModalProps {
   visible: boolean
@@ -65,6 +66,7 @@ export function DatePickerModal(
     })
 
   const isTransparent = presentationStyle === 'pageSheet' ? false : true
+  const insets = useSafeAreaInsets()
 
   return (
     <View style={[StyleSheet.absoluteFill]} pointerEvents="box-none">
@@ -103,7 +105,11 @@ export function DatePickerModal(
                 <View
                   style={[
                     {
-                      height: StatusBar.currentHeight,
+                      height: Platform.select({
+                        ios: StatusBar.currentHeight,
+                        android: StatusBar.currentHeight,
+                        web: insets.top,
+                      }),
                       backgroundColor: theme.colors.primary,
                     },
                   ]}

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -64,6 +64,8 @@ export function DatePickerModal(
       default: 'slide',
     })
 
+  const isTransparent = presentationStyle === 'pageSheet' ? false : true
+
   return (
     <View style={[StyleSheet.absoluteFill]} pointerEvents="box-none">
       <Modal

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -15,6 +15,7 @@ import DatePickerModalContent, {
   DatePickerModalContentSingleProps,
 } from './DatePickerModalContent'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useHeaderBackgroundColor } from '../utils'
 
 interface DatePickerModalProps {
   visible: boolean
@@ -66,6 +67,7 @@ export function DatePickerModal(
     })
 
   const isTransparent = presentationStyle === 'pageSheet' ? false : true
+  const headerBackgroundColor = useHeaderBackgroundColor()
   const insets = useSafeAreaInsets()
 
   return (
@@ -110,7 +112,11 @@ export function DatePickerModal(
                         android: StatusBar.currentHeight,
                         web: insets.top,
                       }),
-                      backgroundColor: theme.colors.primary,
+                      backgroundColor: Platform.select({
+                        ios: theme.colors.primary,
+                        android: theme.colors.primary,
+                        web: headerBackgroundColor,
+                      }),
                     },
                   ]}
                 />


### PR DESCRIPTION
Fix #309

After a lot of research, the problem was the `Statusbar`.
I don't know if is the best solution but works.
Now the modal opens fluently

### CURRENTLY BEHAVIOUR
![problem modal jump](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/519fe5d3-ae61-4134-a413-65ae53812311)

### AFTER SOLUTION
![fixed modal jump](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/4faf47b5-69b1-4caa-8e0d-876aa7ebc9c9)
