### PR TITLE
Added web responsiveness back to date input field

### DIFF
--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -141,15 +141,18 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'flex-start',
+    width: '100%',
   },
   inputContainer: {
     flexGrow: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-start',
+    width: '100%',
   },
   input: {
     flexGrow: 1,
+    width: '100%',
   },
 })
 export default React.forwardRef(DatePickerInputWithoutModal)

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -3862,6 +3862,7 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
             "alignItems": "flex-start",
             "flexGrow": 1,
             "justifyContent": "center",
+            "width": "100%",
           }
         }
       >
@@ -3872,6 +3873,7 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
               "flexDirection": "row",
               "flexGrow": 1,
               "justifyContent": "flex-start",
+              "width": "100%",
             }
           }
         >
@@ -3885,6 +3887,7 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
                 },
                 {
                   "flexGrow": 1,
+                  "width": "100%",
                 },
               ]
             }

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`renders CalendarEdit 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "flexGrow": 1,
-          "justifyContent": "flex-start",,
+          "justifyContent": "flex-start",
           "width": "100%",
         }
       }
@@ -38,7 +38,7 @@ exports[`renders CalendarEdit 1`] = `
               "borderTopRightRadius": 4,
             },
             {
-              "flexGrow": 1,,
+              "flexGrow": 1,
               "width": "100%",
             },
           ]

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`renders CalendarEdit 1`] = `
         "alignItems": "flex-start",
         "flexGrow": 1,
         "justifyContent": "center",
+        "width": "100%",
       }
     }
   >
@@ -23,7 +24,8 @@ exports[`renders CalendarEdit 1`] = `
           "alignItems": "center",
           "flexDirection": "row",
           "flexGrow": 1,
-          "justifyContent": "flex-start",
+          "justifyContent": "flex-start",,
+          "width": "100%",
         }
       }
     >
@@ -36,7 +38,8 @@ exports[`renders CalendarEdit 1`] = `
               "borderTopRightRadius": 4,
             },
             {
-              "flexGrow": 1,
+              "flexGrow": 1,,
+              "width": "100%",
             },
           ]
         }

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`renders DatePickerInput 1`] = `
       "alignItems": "flex-start",
       "flexGrow": 1,
       "justifyContent": "center",
+      "width": "100%",
     }
   }
 >
@@ -17,6 +18,7 @@ exports[`renders DatePickerInput 1`] = `
         "flexDirection": "row",
         "flexGrow": 1,
         "justifyContent": "flex-start",
+        "width": "100%",
       }
     }
   >
@@ -30,6 +32,7 @@ exports[`renders DatePickerInput 1`] = `
           },
           {
             "flexGrow": 1,
+            "width": "100%",
           },
         ]
       }


### PR DESCRIPTION
This PR addresses [324](https://github.com/web-ridge/react-native-paper-dates/issues/324).