### PR TITLE
Added note in contributing guide explaining how to make yarn usable on a windows machine

### DIFF
--- a/docusaurus/docs/contributing.md
+++ b/docusaurus/docs/contributing.md
@@ -8,6 +8,8 @@ We want this community to be friendly and respectful to each other. Please follo
 
 ## Development workflow
 
+> **Working on a Windows machine?** Before executing any of the commands below, please make sure to comment out the line: `yarn-path "scripts/bootstrap.js"` in the `.yarnrc` file located at the project's root.
+
 To get started with the project, run `yarn bootstrap` in the root directory to install the required dependencies for each package:
 
 ```sh


### PR DESCRIPTION
As we discussed in this [issue](https://github.com/web-ridge/react-native-paper-dates/issues/314) I have added a note in contributing guide explaining how to make yarn usable on a windows machine.

**Final result**
![image](https://github.com/web-ridge/react-native-paper-dates/assets/4748759/334402b6-4a8f-4e2a-b41d-f1e6e7396ac9)
