### PR TITLE
chore: Fixed responsiveness DatePickerInput

### DIFF
--- a/src/Date/DatePickerInputWithoutModal.tsx
+++ b/src/Date/DatePickerInputWithoutModal.tsx
@@ -138,6 +138,7 @@ function getLabel({
 
 const styles = StyleSheet.create({
   root: {
+    flex: 1,
     flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'flex-start',

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -3860,6 +3860,7 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
         style={
           {
             "alignItems": "flex-start",
+            "flex": 1,
             "flexGrow": 1,
             "justifyContent": "center",
             "width": "100%",
@@ -4044,6 +4045,10 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
                       "margin": 0,
                     },
                     {
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                    },
+                    {
                       "height": 56,
                     },
                     {
@@ -4057,8 +4062,6 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
                       "fontWeight": undefined,
                       "letterSpacing": 0.15,
                       "lineHeight": undefined,
-                      "paddingLeft": 16,
-                      "paddingRight": 16,
                       "textAlign": "left",
                       "textAlignVertical": "center",
                     },

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -4045,10 +4045,6 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
                       "margin": 0,
                     },
                     {
-                      "paddingLeft": 16,
-                      "paddingRight": 16,
-                    },
-                    {
                       "height": 56,
                     },
                     {
@@ -4062,6 +4058,8 @@ exports[`renders collapsed AnimatedCrossView 1`] = `
                       "fontWeight": undefined,
                       "letterSpacing": 0.15,
                       "lineHeight": undefined,
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
                       "textAlign": "left",
                       "textAlignVertical": "center",
                     },

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`renders CalendarEdit 1`] = `
     style={
       {
         "alignItems": "flex-start",
+        "flex": 1,
         "flexGrow": 1,
         "justifyContent": "center",
         "width": "100%",
@@ -196,6 +197,10 @@ exports[`renders CalendarEdit 1`] = `
                   "margin": 0,
                 },
                 {
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                },
+                {
                   "height": 56,
                 },
                 {
@@ -209,8 +214,6 @@ exports[`renders CalendarEdit 1`] = `
                   "fontWeight": undefined,
                   "letterSpacing": 0.15,
                   "lineHeight": undefined,
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
                   "textAlign": "left",
                   "textAlignVertical": "center",
                 },

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -197,10 +197,6 @@ exports[`renders CalendarEdit 1`] = `
                   "margin": 0,
                 },
                 {
-                  "paddingLeft": 16,
-                  "paddingRight": 16,
-                },
-                {
                   "height": 56,
                 },
                 {
@@ -214,6 +210,8 @@ exports[`renders CalendarEdit 1`] = `
                   "fontWeight": undefined,
                   "letterSpacing": 0.15,
                   "lineHeight": undefined,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
                   "textAlign": "left",
                   "textAlignVertical": "center",
                 },

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -189,10 +189,6 @@ exports[`renders DatePickerInput 1`] = `
                 "margin": 0,
               },
               {
-                "paddingLeft": 16,
-                "paddingRight": 16,
-              },
-              {
                 "height": 56,
               },
               {
@@ -206,6 +202,8 @@ exports[`renders DatePickerInput 1`] = `
                 "fontWeight": undefined,
                 "letterSpacing": 0.15,
                 "lineHeight": undefined,
+                "paddingLeft": 16,
+                "paddingRight": 16,
                 "textAlign": "left",
                 "textAlignVertical": "center",
               },

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`renders DatePickerInput 1`] = `
   style={
     {
       "alignItems": "flex-start",
+      "flex": 1,
       "flexGrow": 1,
       "justifyContent": "center",
       "width": "100%",
@@ -188,6 +189,10 @@ exports[`renders DatePickerInput 1`] = `
                 "margin": 0,
               },
               {
+                "paddingLeft": 16,
+                "paddingRight": 16,
+              },
+              {
                 "height": 56,
               },
               {
@@ -201,8 +206,6 @@ exports[`renders DatePickerInput 1`] = `
                 "fontWeight": undefined,
                 "letterSpacing": 0.15,
                 "lineHeight": undefined,
-                "paddingLeft": 16,
-                "paddingRight": 16,
                 "textAlign": "left",
                 "textAlignVertical": "center",
               },


### PR DESCRIPTION
Fix #324 

The PR https://github.com/web-ridge/react-native-paper-dates/pull/326 had generated an overflow.

![image](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/18fdea8b-e520-4a01-88f1-d9fa9f6c63c8)

This fix solves the problem and works perfectly (Tested in Android and Web)

![fixed dates responsiveness](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/e77fe797-a8a5-4871-8af1-9f8bde23d1c7)
