### PR TITLE
Default input type for time picker

### DIFF
--- a/docusaurus/docs/time-picker.md
+++ b/docusaurus/docs/time-picker.md
@@ -113,3 +113,7 @@ Flag indicating if the time input should use the 24 hours clock. Defaults to the
 **inputFontSize**
 `Type: number | undefined`
 Font size of the time input. Defaults to 57. Useful when using a custom font.
+
+**defaultInputType**
+`Type: 'picker' | 'keyboard'`
+Which input type to use by default. Defaults to the clock-face picker.

--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -57,6 +57,7 @@ export function TimePickerModal({
   clockIcon = 'clock-outline',
   use24HourClock,
   inputFontSize,
+  defaultInputType,
 }: {
   locale?: undefined | string
   label?: string
@@ -73,6 +74,7 @@ export function TimePickerModal({
   clockIcon?: string
   use24HourClock?: boolean
   inputFontSize?: number
+    defaultInputType?: PossibleInputTypes
 }) {
   const theme = useTheme()
 
@@ -86,7 +88,7 @@ export function TimePickerModal({
   }
 
   const [inputType, setInputType] = React.useState<PossibleInputTypes>(
-    inputTypes.picker
+    defaultInputType || inputTypes.picker
   )
   const [focused, setFocused] = React.useState<PossibleClockTypes>(
     clockTypes.hours

--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -74,7 +74,7 @@ export function TimePickerModal({
   clockIcon?: string
   use24HourClock?: boolean
   inputFontSize?: number
-    defaultInputType?: PossibleInputTypes
+  defaultInputType?: PossibleInputTypes
 }) {
   const theme = useTheme()
 


### PR DESCRIPTION
fixes: https://github.com/web-ridge/react-native-paper-dates/issues/330

TimePickerModal now accepts a prop `defaultInputType`, which can be used to set which input is shown first.