### PR TITLE
Added prop presentationStyle in DatePickerInput

### DIFF
--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -26,7 +26,11 @@ export type DatePickerInputProps = {
   inputEnabled?: boolean
   disableStatusBarPadding?: boolean
   animationType?: 'slide' | 'fade' | 'none'
-  presentationStyle?: 'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'
+  presentationStyle?:
+    | 'fullScreen'
+    | 'pageSheet'
+    | 'formSheet'
+    | 'overFullScreen'
 } & Omit<
   React.ComponentProps<typeof TextInput>,
   'value' | 'onChange' | 'onChangeText' | 'inputMode'

--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -26,6 +26,7 @@ export type DatePickerInputProps = {
   inputEnabled?: boolean
   disableStatusBarPadding?: boolean
   animationType?: 'slide' | 'fade' | 'none'
+  presentationStyle?: 'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'
 } & Omit<
   React.ComponentProps<typeof TextInput>,
   'value' | 'onChange' | 'onChangeText' | 'inputMode'

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -12,7 +12,7 @@ function DatePickerInput(
     withModal = true,
     calendarIcon = 'calendar',
     animationType = 'slide',
-    presentationStyle = "fullScreen",
+    presentationStyle = 'fullScreen',
     ...rest
   }: DatePickerInputProps,
   ref: any

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -12,6 +12,7 @@ function DatePickerInput(
     withModal = true,
     calendarIcon = 'calendar',
     animationType = 'slide',
+    presentationStyle = "fullScreen",
     ...rest
   }: DatePickerInputProps,
   ref: any
@@ -78,6 +79,7 @@ function DatePickerInput(
             inputEnabled={inputEnabled}
             disableStatusBarPadding={disableStatusBarPadding ?? false}
             animationType={animationType}
+            presentationStyle={presentationStyle}
           />
         ) : null
       }


### PR DESCRIPTION
Added prop presentationStyle in DatePickerInput

For iOS especially sometimes the Modal is behind the Notification bar and is not clickable to close or save. Using 
presentationStyle="pageSheet" 
we can configure it to show up as sheet on iOS