### PR TITLE
Fixing Date Picker Modal Overlapping StatusBar in iOS

### DIFF
--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -6,6 +6,7 @@ import {
   useWindowDimensions,
   View,
   Platform,
+  NativeModules,
   StatusBar,
 } from 'react-native'
 import { useTheme } from 'react-native-paper'
@@ -69,6 +70,7 @@ export function DatePickerModal(
   const isTransparent = presentationStyle === 'pageSheet' ? false : true
   const headerBackgroundColor = useHeaderBackgroundColor()
   const insets = useSafeAreaInsets()
+  const {StatusBarManager} = NativeModules;
 
   return (
     <View style={[StyleSheet.absoluteFill]} pointerEvents="box-none">
@@ -103,12 +105,14 @@ export function DatePickerModal(
                 dimensions.width > 650 ? styles.modalContentBig : null,
               ]}
             >
-              {disableStatusBarPadding ? null : (
+              
+              {disableStatusBarPadding ? null : 
+              (
                 <View
                   style={[
                     {
                       height: Platform.select({
-                        ios: StatusBar.currentHeight,
+                        ios: StatusBarManager.HEIGHT ,
                         android: StatusBar.currentHeight,
                         web: insets.top,
                       }),

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -105,9 +105,7 @@ export function DatePickerModal(
                 dimensions.width > 650 ? styles.modalContentBig : null,
               ]}
             >
-              
-              {disableStatusBarPadding ? null : 
-              (
+              {disableStatusBarPadding ? null : (
                 <View
                   style={[
                     {


### PR DESCRIPTION
Hello,

This PR resolves the issue where the content of the date picker modal in iOS is displayed under the StatusBar, preventing users from interacting with the close and save buttons. The problem arose due to the use of an incorrect property for calculating the StatusBar height in the DatePickerModal component for iOS. This fix replaces the incorrect property StatusBar.currentHeight with the appropriate StatusBarManager.HEIGHT for iOS. The changes ensure that the content is properly displayed and the user can interact with the necessary buttons within the date picker modal.

Changes Made:
- Replaced the usage of StatusBar.currentHeight with StatusBarManager.HEIGHT for calculating the StatusBar's height in the DatePickerModal component for iOS.
- Tested the changes on iOS to ensure the proper functioning of the date picker modal and the interaction with the buttons.

Fixes: https://github.com/web-ridge/react-native-paper-dates/issues/258#issue-1602789368

Thanks.