### PR TITLE
fix(calendar): Detect orientation and change scrollMode

### DIFF
--- a/src/Date/Calendar.tsx
+++ b/src/Date/Calendar.tsx
@@ -16,6 +16,7 @@ import YearPicker from './YearPicker'
 import Color from 'color'
 import { useTheme } from 'react-native-paper'
 import { useLatest, lightenBy, darkenBy } from '../utils'
+import { Dimensions } from 'react-native'
 
 export type ModeType = 'single' | 'range' | 'multiple'
 
@@ -109,8 +110,34 @@ function Calendar(
     return lightenBy(Color(theme.colors.primary), 0.9).hex()
   }, [theme])
 
-  const scrollMode =
-    mode === 'range' || mode === 'multiple' ? 'vertical' : 'horizontal'
+  const [isLandscape, setIsLandscape] = React.useState(
+    Dimensions.get('window').width > Dimensions.get('window').height
+  )
+
+  const [scrollMode, setScrollMode] = React.useState<'vertical' | 'horizontal'>(
+    mode === 'range' || mode === 'multiple' || isLandscape
+      ? 'vertical'
+      : 'horizontal'
+  )
+
+  React.useEffect(() => {
+    const handleOrientationChange = () => {
+      const newIsLandscape =
+        Dimensions.get('window').width > Dimensions.get('window').height
+      setIsLandscape(newIsLandscape)
+      setScrollMode(
+        mode === 'range' || mode === 'multiple' || newIsLandscape
+          ? 'vertical'
+          : 'horizontal'
+      )
+    }
+
+    Dimensions.addEventListener('change', handleOrientationChange)
+
+    return () => {
+      Dimensions.addEventListener('change', handleOrientationChange).remove()
+    }
+  }, [mode])
 
   const [selectedYear, setSelectedYear] = React.useState<number | undefined>(
     undefined


### PR DESCRIPTION
Fix #355.

# Read below ⚠️ 

## POSSIBLE SOLUTION AT THE MOMENT

![landscape mode](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/2eea7904-fff1-4517-a136-f51f28acbb0e)

Is not **100% ok**, we should improve it. I was able to made scrollable the calendar and works perfectly If you are in mode `portrait` all time or if you are in mode `landscape` all time. But if you open the modal in `portrait` and you rotate to `landscape` the scroll will works, but the layout will breaks. 
@RichardLindhout I hope can help us to solve this problem.

### Layout when you change from `portrait` to `landscape`.

![image](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/71989b58-8e8e-4e97-a219-ab6738e3eeb0)

### Layout when you change from `landscape` to `portrait`.

![image](https://github.com/web-ridge/react-native-paper-dates/assets/19764334/96c1d41a-37be-466b-bca3-d190730d2998)


