### PR TITLE
Add translations for 'Hour' and 'Minute' in TimeInputs component

### DIFF
--- a/src/Time/TimeInputs.tsx
+++ b/src/Time/TimeInputs.tsx
@@ -18,6 +18,7 @@ import TimeInput from './TimeInput'
 import AmPmSwitcher from './AmPmSwitcher'
 import { useLatest } from '../utils'
 import Color from 'color'
+import { getTranslation } from '../translations/utils'
 
 function TimeInputs({
   hours,
@@ -28,6 +29,7 @@ function TimeInputs({
   onChange,
   is24Hour,
   inputFontSize,
+  locale,
 }: {
   inputType: PossibleInputTypes
   focused: PossibleClockTypes
@@ -41,6 +43,7 @@ function TimeInputs({
   }) => any
   is24Hour: boolean
   inputFontSize?: number
+  locale?: string
 }) {
   const startInput = React.useRef<TextInputNative | null>(null)
   const endInput = React.useRef<TextInputNative | null>(null)
@@ -113,7 +116,7 @@ function TimeInputs({
         />
         {inputType === 'keyboard' ? (
           <Text maxFontSizeMultiplier={1.5} variant="bodySmall">
-            Hour
+            {getTranslation(locale, 'hour', 'Hour')}
           </Text>
         ) : null}
       </View>
@@ -178,7 +181,7 @@ function TimeInputs({
         />
         {inputType === 'keyboard' ? (
           <Text maxFontSizeMultiplier={1.5} variant="bodySmall">
-            Minute
+            {getTranslation(locale, 'minute', 'Minute')}
           </Text>
         ) : null}
       </View>

--- a/src/Time/TimePicker.tsx
+++ b/src/Time/TimePicker.tsx
@@ -114,6 +114,7 @@ function TimePicker({
           onChange={onChange}
           onFocusInput={onFocusInput}
           focused={focused}
+          locale={locale}
         />
         {inputType === inputTypes.picker ? (
           <View style={styles.clockContainer}>

--- a/src/translations/ar.ts
+++ b/src/translations/ar.ts
@@ -17,5 +17,7 @@ const ar: TranslationsType = {
   typeInDate: 'اكتب التاريخ',
   pickDateFromCalendar: 'اختر التاريخ من التقويم',
   close: 'أغلق',
+  hour: 'ساعة',
+  minute: 'دقيقة',
 }
 export default ar

--- a/src/translations/ca.ts
+++ b/src/translations/ca.ts
@@ -17,5 +17,7 @@ const ca: TranslationsType = {
   typeInDate: 'Escriu la data',
   pickDateFromCalendar: 'Seleccionar la data del calendari',
   close: 'Tancar',
+  minute: 'Minut',
+  hour: 'Hora',
 }
 export default ca

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -17,5 +17,7 @@ const cs: TranslationsType = {
   typeInDate: 'Zadejte datum',
   pickDateFromCalendar: 'Vyberte datum z kalendáře',
   close: 'Zavřít',
+  minute: 'minuta',
+  hour: 'hodina',
 }
 export default cs

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -17,5 +17,7 @@ const de: TranslationsType = {
   typeInDate: 'Datum eingeben',
   pickDateFromCalendar: 'Datum vom Kalender auswählen',
   close: 'Schliessen',
+  minute: 'Minute',
+  hour: 'Stunde',
 }
 export default de

--- a/src/translations/el.ts
+++ b/src/translations/el.ts
@@ -17,5 +17,7 @@ const el: TranslationsType = {
   typeInDate: 'Πληκτρολογήστε την ημερομηνία',
   pickDateFromCalendar: 'Επιλέξτε ημερομηνία από το ημερολόγιο',
   close: 'Κλείσε',
+  minute: 'λεπτό',
+  hour: 'ώρα',
 }
 export default el

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -17,5 +17,7 @@ const en: TranslationsType = {
   typeInDate: 'Type in date',
   pickDateFromCalendar: 'Pick date from calendar',
   close: 'Close',
+  minute: 'Minute',
+  hour: 'Hour',
 }
 export default en

--- a/src/translations/enGB.ts
+++ b/src/translations/enGB.ts
@@ -17,5 +17,7 @@ const enGB: TranslationsType = {
   typeInDate: 'Type in date',
   pickDateFromCalendar: 'Pick date from calendar',
   close: 'Close',
+  hour: 'Hour',
+  minute: 'Minute',
 }
 export default enGB

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -17,5 +17,7 @@ const es: TranslationsType = {
   typeInDate: 'Escribir fecha',
   pickDateFromCalendar: 'Seleccionar fecha del calendario',
   close: 'Cerrar',
+  hour: 'Hora',
+  minute: 'Minuto',
 }
 export default es

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -17,5 +17,7 @@ const fr: TranslationsType = {
   typeInDate: 'Entrer la date',
   pickDateFromCalendar: 'Sélectionner une date dans le calendrier',
   close: 'Fermer',
+  minute: 'minutes',
+  hour: 'heures',
 }
 export default fr

--- a/src/translations/he.ts
+++ b/src/translations/he.ts
@@ -17,5 +17,7 @@ const he: TranslationsType = {
   typeInDate: 'הקש תאריך',
   pickDateFromCalendar: 'בחר תאריך מהלוח שנה',
   close: 'סגור',
+  hour: 'שעה',
+  minute: 'דקה',
 }
 export default he

--- a/src/translations/hi.ts
+++ b/src/translations/hi.ts
@@ -17,5 +17,7 @@ const hi: TranslationsType = {
   typeInDate: 'तारीख़ लिखें',
   pickDateFromCalendar: 'कैलेंडर से तारीख़ चुनें',
   close: 'बंद करें',
+  minute: 'मिनट',
+  hour: 'घंटा',
 }
 export default hi

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -17,5 +17,7 @@ const it: TranslationsType = {
   typeInDate: 'Digita la data',
   pickDateFromCalendar: 'Scegli data dal calendario',
   close: 'Chiudi',
+  hour: 'Ora',
+  minute: 'Minuto',
 }
 export default it

--- a/src/translations/ko.ts
+++ b/src/translations/ko.ts
@@ -17,5 +17,7 @@ const ko: TranslationsType = {
   typeInDate: '날짜 입력',
   pickDateFromCalendar: '달력에서 날짜 선택',
   close: '닫기',
+  minute: '분',
+  hour: '시',
 }
 export default ko

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -17,5 +17,7 @@ const nl: TranslationsType = {
   typeInDate: 'Typ datum',
   pickDateFromCalendar: 'Kies datum van kalender',
   close: 'Sluit',
+  hour: 'Uur',
+  minute: 'Minuut',
 }
 export default nl

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -11,11 +11,12 @@ const pl: TranslationsType = {
   mustBeLowerThan: (date) => `Nie później niż ${date}`,
   mustBeBetween: (startDate, endDate) => `Pomiędzy ${startDate} - ${endDate}`,
   dateIsDisabled: 'Niedozwolona data',
-
   previous: 'Poprzedni',
   next: 'Dalej',
   typeInDate: 'Wpisz datę',
   pickDateFromCalendar: 'Wybierz datę z kalendarza',
   close: 'Zamknij',
+  minute: 'Minuta',
+  hour: 'Godzina',
 }
 export default pl

--- a/src/translations/pt.ts
+++ b/src/translations/pt.ts
@@ -17,5 +17,7 @@ const pt: TranslationsType = {
   typeInDate: 'Digite a data',
   pickDateFromCalendar: 'Escolha a data do calendário',
   close: 'Fechar',
+  hour: 'Hora',
+  minute: 'Minuto',
 }
 export default pt

--- a/src/translations/ro.ts
+++ b/src/translations/ro.ts
@@ -17,5 +17,7 @@ const ro: TranslationsType = {
   typeInDate: 'Tipul în dată',
   pickDateFromCalendar: 'Alege o dată din calendar',
   close: 'Închide',
+  minute: 'Minut',
+  hour: 'Oră',
 }
 export default ro

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -17,5 +17,7 @@ const ru: TranslationsType = {
   typeInDate: 'Ввод в дате',
   pickDateFromCalendar: 'Выбор даты из календаря',
   close: 'Закрыть',
+  hour: 'Час',
+  minute: 'Минута',
 }
 export default ru

--- a/src/translations/tr.ts
+++ b/src/translations/tr.ts
@@ -17,5 +17,7 @@ const tr: TranslationsType = {
   typeInDate: 'Tarihi yazın',
   pickDateFromCalendar: 'Takvimden tarih seçin',
   close: 'Kapat',
+  minute: 'Dakika',
+  hour: 'Saat',
 }
 export default tr

--- a/src/translations/utils.ts
+++ b/src/translations/utils.ts
@@ -13,6 +13,8 @@ export type TranslationsType = {
   typeInDate: string
   pickDateFromCalendar: string
   close: string
+  hour: string
+  minute: string
 }
 
 let translationsPerLocale: Record<string, TranslationsType> = {}

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -16,5 +16,7 @@ const zh: TranslationsType = {
   typeInDate: '输入日期',
   pickDateFromCalendar: '从日历中选择日期',
   close: '关闭',
+  hour: '小时',
+  minute: '分钟',
 }
 export default zh

--- a/src/translations/zhTW.ts
+++ b/src/translations/zhTW.ts
@@ -16,6 +16,8 @@ const zhTW: TranslationsType = {
   typeInDate: '輸入日期',
   pickDateFromCalendar: '從日曆中選擇日期',
   close: '關閉',
+  minute: '分鐘',
+  hour: '小時',
 }
 
 export default zhTW


### PR DESCRIPTION
This pull request aims to add translations for the words 'Hour' and 'Minute' in the `TimeInputs` component of the library.

Previously, these words were in English regardless of the language set in the application. With this change, the user experience is improved by providing a consistent and fully translated user interface.

Changes made:
- Added translations for 'Hour' and 'Minute' in the `TimeInputs` component.