### PR TITLE
fix landscape flickering bug

### DIFF
--- a/src/Date/AutoSizer.tsx
+++ b/src/Date/AutoSizer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { LayoutChangeEvent, StyleSheet, View } from 'react-native'
+import { Dimensions, LayoutChangeEvent, StyleSheet, View } from 'react-native'
 
 type WidthAndHeight = {
   width: number
@@ -15,9 +15,17 @@ export default function AutoSizer({
   const onLayout = React.useCallback(
     (event: LayoutChangeEvent) => {
       const nl = event.nativeEvent.layout
+      const windowDimensions = Dimensions.get('window')
+      const isLandscapeScreen = windowDimensions.width > windowDimensions.height
 
       // https://github.com/necolas/react-native-web/issues/1704
-      if (!layout || layout.width !== nl.width || layout.height !== nl.height) {
+      if (!layout) {
+        setLayout({ width: nl.width, height: nl.height })
+        return
+      }
+      if (isLandscapeScreen && nl.width < layout.width) {
+        return
+      } else if (layout.width !== nl.width || layout.height !== nl.height) {
         setLayout({ width: nl.width, height: nl.height })
       }
     },


### PR DESCRIPTION
At landscape screens, date component was flickering due to infinite loop into useCallback hook. 
Here you may find an example:
https://github.com/web-ridge/react-native-paper-dates/assets/52549674/c6db7e31-dda5-4128-bdc4-ae8ba897a36b

Due to React-Native issues onLayout triggers more than once when landscape mode, and its creates infinite loop. I added more checks than before to fix it. I am not familiar the entire library, might be better approach please carefully review it.


Thanks