### PR TITLE
fix: add correct roundness to time picker modal

### DIFF
--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -169,8 +169,10 @@ export function TimePickerModal({
             <Animated.View
               style={[
                 styles.modalContent,
+                // eslint-disable-next-line react-native/no-inline-styles
                 {
                   backgroundColor: theme.isV3 ? v3Color : v2Color,
+                  borderRadius: theme.isV3 ? 28 : undefined,
                 },
               ]}
             >


### PR DESCRIPTION
# Motivation

<img width="913" alt="Screenshot 2024-03-31 at 7 41 58 AM" src="https://github.com/web-ridge/react-native-paper-dates/assets/7604441/667e0779-1d16-459c-bfa7-cbdcdfe5116d">

The current time picker modal is not rounded (square) for version 3, so it is now set to 28 per the specs. I'm not sure if it'd be more beneficial to use `theme.roundness`, but then it would have to be dynamically calculated.

<img width="878" alt="Screenshot 2024-03-31 at 7 42 40 AM" src="https://github.com/web-ridge/react-native-paper-dates/assets/7604441/423384bc-d0d6-45fd-9274-c5d6e9b19dd2">
