### PR TITLE
Fix v2 dark theme

### DIFF
--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -133,9 +133,7 @@ export function TimePickerModal({
 
   let color
   if (theme.isV3) {
-    color = theme.dark
-      ? theme.colors.elevation.level3
-      : theme.colors.surface
+    color = theme.dark ? theme.colors.elevation.level3 : theme.colors.surface
   } else {
     color = theme.dark
       ? overlay(10, theme.colors.surface)

--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -131,12 +131,16 @@ export function TimePickerModal({
     [setFocused, setLocalHours, setLocalMinutes]
   )
 
-  const v3Color = theme.dark
-    ? theme.colors.elevation.level3
-    : theme.colors.surface
-  const v2Color = theme.dark
-    ? overlay(10, theme.colors.surface)
-    : theme.colors.surface
+  let color
+  if (theme.isV3) {
+    color = theme.dark
+      ? theme.colors.elevation.level3
+      : theme.colors.surface
+  } else {
+    color = theme.dark
+      ? overlay(10, theme.colors.surface)
+      : theme.colors.surface
+  }
 
   return (
     <Modal
@@ -171,7 +175,7 @@ export function TimePickerModal({
                 styles.modalContent,
                 // eslint-disable-next-line react-native/no-inline-styles
                 {
-                  backgroundColor: theme.isV3 ? v3Color : v2Color,
+                  backgroundColor: color,
                   borderRadius: theme.isV3 ? 28 : undefined,
                 },
               ]}


### PR DESCRIPTION
https://github.com/web-ridge/react-native-paper-dates/commit/e9d69556b50cdf5df70c6df440818d6b3454e387 introduced a bug where if the app is using a Material V2 dark theme, the time picker will access a color property which isn't defined, resulting in a hard crash with a "Cannot read property 'level3' of undefined". 

This is due to the previous logic gating on `theme.isV3` before accessing the property, while the current logic does not gate on this. 

This PR changes the logic to be similar to the change to [Day.tsx](https://github.com/web-ridge/react-native-paper-dates/commit/e9d69556b50cdf5df70c6df440818d6b3454e387#diff-a9529d1fba70bb307f3d24f1b57f81660d2a9cb03e7a9a86c2cd63bde46e09d0), which does check if the theme is V3 before accessing potentially undefined properties.

We have deployed this change to our app, and it has fixed the crashes our users were seeing.