### PR TITLE
Fix keyboard flash issue with TextInput.Icon and DatePicker modal

### DIFF
--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -40,6 +40,7 @@ function DatePickerInput(
             size={rest.iconSize ?? 24}
             icon={calendarIcon}
             color={rest.iconColor ?? undefined}
+            forceTextInputFocus={false}
             disabled={rest.disabled}
             onPress={() => setVisible(true)}
             style={rest.iconStyle as StyleProp<ViewStyle>}


### PR DESCRIPTION
When using TextInput.Icon and a DatePicker modal on slower devices, a virtual keyboard briefly appears due to premature input focus. To address this, I propose adding a forceTextInputFocus prop with a value of false. This change should prevent the keyboard from showing up unnecessarily.