### PR TITLE
Fix edit-input-field to respect disabling format in label and placeholder

### DIFF
--- a/src/Date/CalendarEdit.tsx
+++ b/src/Date/CalendarEdit.tsx
@@ -25,6 +25,7 @@ function CalendarEdit({
   locale,
   inputEnabled,
   withDateFormatInLabel,
+  placeholder,
 }: {
   mode: ModeType
   label?: string
@@ -37,6 +38,7 @@ function CalendarEdit({
   locale: string
   inputEnabled?: boolean
   withDateFormatInLabel?: boolean
+  placeholder?: string
 }) {
   const dateInput = useRef<TextInputNative | null>(null)
   const startInput = useRef<TextInputNative | null>(null)
@@ -96,6 +98,7 @@ function CalendarEdit({
           autoComplete={'off'}
           inputEnabled={inputEnabled}
           withDateFormatInLabel={withDateFormatInLabel}
+          placeholder={placeholder}
         />
       ) : null}
       {mode === 'range' ? (
@@ -114,6 +117,7 @@ function CalendarEdit({
             autoComplete={'off'}
             inputEnabled={inputEnabled}
             withDateFormatInLabel={withDateFormatInLabel}
+            placeholder={placeholder}
           />
           <View style={styles.separator} />
           <DatePickerInputWithoutModal
@@ -129,6 +133,7 @@ function CalendarEdit({
             autoComplete="off"
             inputEnabled={inputEnabled}
             withDateFormatInLabel={withDateFormatInLabel}
+            placeholder={placeholder}
           />
         </View>
       ) : null}

--- a/src/Date/CalendarEdit.tsx
+++ b/src/Date/CalendarEdit.tsx
@@ -24,6 +24,7 @@ function CalendarEdit({
   validRange,
   locale,
   inputEnabled,
+  withDateFormatInLabel,
 }: {
   mode: ModeType
   label?: string
@@ -35,6 +36,7 @@ function CalendarEdit({
   validRange: ValidRangeType | undefined
   locale: string
   inputEnabled?: boolean
+  withDateFormatInLabel?: boolean
 }) {
   const dateInput = useRef<TextInputNative | null>(null)
   const startInput = useRef<TextInputNative | null>(null)
@@ -93,6 +95,7 @@ function CalendarEdit({
           withModal={false}
           autoComplete={'off'}
           inputEnabled={inputEnabled}
+          withDateFormatInLabel={withDateFormatInLabel}
         />
       ) : null}
       {mode === 'range' ? (
@@ -110,6 +113,7 @@ function CalendarEdit({
             withModal={false}
             autoComplete={'off'}
             inputEnabled={inputEnabled}
+            withDateFormatInLabel={withDateFormatInLabel}
           />
           <View style={styles.separator} />
           <DatePickerInputWithoutModal
@@ -124,6 +128,7 @@ function CalendarEdit({
             withModal={false}
             autoComplete="off"
             inputEnabled={inputEnabled}
+            withDateFormatInLabel={withDateFormatInLabel}
           />
         </View>
       ) : null}

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -87,6 +87,7 @@ function DatePickerInput(
             presentationStyle={presentationStyle}
             label={rest.label as any}
             startWeekOnMonday={startWeekOnMonday}
+            withDateFormatInLabel={rest.withDateFormatInLabel}
           />
         ) : null
       }

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -88,6 +88,7 @@ function DatePickerInput(
             label={rest.label as any}
             startWeekOnMonday={startWeekOnMonday}
             withDateFormatInLabel={rest.withDateFormatInLabel}
+            placeholder={rest.placeholder}
           />
         ) : null
       }

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -102,6 +102,7 @@ export function DatePickerModal(
               disableStatusBar={disableStatusBar}
               statusBarOnTopOfBackdrop={isPageSheet || statusBarOnTopOfBackdrop}
               withDateFormatInLabel={props.withDateFormatInLabel}
+              placeholder={props.placeholder}
             />
           </View>
         </View>

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -101,6 +101,7 @@ export function DatePickerModal(
               disableSafeTop={disableStatusBarPadding}
               disableStatusBar={disableStatusBar}
               statusBarOnTopOfBackdrop={isPageSheet || statusBarOnTopOfBackdrop}
+              withDateFormatInLabel={props.withDateFormatInLabel}
             />
           </View>
         </View>

--- a/src/Date/DatePickerModalContent.tsx
+++ b/src/Date/DatePickerModalContent.tsx
@@ -212,6 +212,7 @@ export function DatePickerModalContent(
             validRange={validRange}
             locale={locale}
             inputEnabled={props.inputEnabled}
+            withDateFormatInLabel={props.withDateFormatInLabel}
           />
         }
       />

--- a/src/Date/DatePickerModalContent.tsx
+++ b/src/Date/DatePickerModalContent.tsx
@@ -213,6 +213,7 @@ export function DatePickerModalContent(
             locale={locale}
             inputEnabled={props.inputEnabled}
             withDateFormatInLabel={props.withDateFormatInLabel}
+            placeholder={props.placeholder}
           />
         }
       />

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -12,6 +12,7 @@ export interface HeaderPickProps {
   moreLabel?: string
   label?: string
   emptyLabel?: string
+  withDateFormatInLabel?: boolean
   saveLabel?: string
   uppercase?: boolean
   headerSeparator?: string

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -13,6 +13,7 @@ export interface HeaderPickProps {
   label?: string
   emptyLabel?: string
   withDateFormatInLabel?: boolean
+  placeholder?: string
   saveLabel?: string
   uppercase?: boolean
   headerSeparator?: string


### PR DESCRIPTION
As described in [https://github.com/web-ridge/react-native-paper-dates/issues/430](https://github.com/web-ridge/react-native-paper-dates/issues/430)

- `withDateFormatInLabel` is now being used in the edit-input-field
- `placeholder` is now being used in the edit-input-field