### PR TITLE
fix: dateToUnix to preserve the date #434

### DIFF
--- a/src/Date/dateUtils.tsx
+++ b/src/Date/dateUtils.tsx
@@ -12,7 +12,7 @@ export function showWeekDay(
 }
 
 export function dateToUnix(d: Date): number {
-  return Math.round(d.getTime() / 1000)
+  return Math.trunc(d.getTime() / 1000)
 }
 
 export function addMonths(date: Date, count: number) {


### PR DESCRIPTION
trunc the ms instead of round to avoid edge cases where the date would be changed example:  Math.round((new Date('2024-12-10T23:59:59.999Z')).getTime() / 1000) vs
Math.trunc((new Date('2024-12-10T23:59:59.999Z')).getTime() / 1000)