### PR TITLE
fix: more sensible date modal styles

### DIFF
--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -117,8 +117,8 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   modalContentBig: {
-    maxWidth: 600,
-    maxHeight: 800,
+    maxWidth: 400,
+    maxHeight: 600,
     borderRadius: 10,
     width: '100%',
     overflow: 'hidden',


### PR DESCRIPTION
This PR sets better defaults for the `DatePickerModal` on larger screens. It makes it look more inline with Material modals.

It changes the modal which looks like this:
![image](https://github.com/user-attachments/assets/127c26da-916f-407c-9760-1ef1bf66bd52)

To this:
<img width="951" alt="Screenshot 2025-01-21 at 14 29 38" src="https://github.com/user-attachments/assets/f92188b2-c4d6-4b85-93a6-a29f4248a831" />
