### PR TITLE
fix: Pixel 8a and 9 series sometimes do not render the calender #442

### DIFF
--- a/src/Date/AutoSizer.tsx
+++ b/src/Date/AutoSizer.tsx
@@ -26,14 +26,14 @@ export default function AutoSizer({
     [layout, setLayout]
   )
 
-  const isLayoutInizialized = layout && layout.height > 0 && layout.width > 0
+  const isLayoutInitialized = layout && layout.height > 0 && layout.width > 0
 
   return (
     <View
       onLayout={onLayout}
-      style={[sharedStyles.overflowHidden, sharedStyles.root, isLayoutInizialized && layout]}
+      style={[sharedStyles.overflowHidden, sharedStyles.root, isLayoutInitialized && layout]}
     >
-      {isLayoutInizialized ? children(layout) : null}
+      {isLayoutInitialized ? children(layout) : null}
     </View>
   )
 }

--- a/src/Date/AutoSizer.tsx
+++ b/src/Date/AutoSizer.tsx
@@ -26,12 +26,14 @@ export default function AutoSizer({
     [layout, setLayout]
   )
 
+  const isLayoutInizialized = layout && layout.height > 0 && layout.width > 0
+
   return (
     <View
       onLayout={onLayout}
-      style={[sharedStyles.overflowHidden, sharedStyles.root, layout && layout]}
+      style={[sharedStyles.overflowHidden, sharedStyles.root, isLayoutInizialized && layout]}
     >
-      {layout ? children(layout) : null}
+      {isLayoutInizialized ? children(layout) : null}
     </View>
   )
 }

--- a/src/Date/AutoSizer.tsx
+++ b/src/Date/AutoSizer.tsx
@@ -31,7 +31,11 @@ export default function AutoSizer({
   return (
     <View
       onLayout={onLayout}
-      style={[sharedStyles.overflowHidden, sharedStyles.root, isLayoutInitialized && layout]}
+      style={[
+        sharedStyles.overflowHidden,
+        sharedStyles.root,
+        isLayoutInitialized && layout,
+      ]}
     >
       {isLayoutInitialized ? children(layout) : null}
     </View>

--- a/src/Date/DatePickerModalContentHeader.tsx
+++ b/src/Date/DatePickerModalContentHeader.tsx
@@ -216,7 +216,7 @@ export function HeaderContentRange({
   const formatter = useMemo(() => {
     return new Intl.DateTimeFormat(locale, {
       month: 'short',
-      day: 'numeric'
+      day: 'numeric',
     })
   }, [locale])
 


### PR DESCRIPTION
This fixes issue #442 (Or a similar problem).

onLayout on Android does not always set the correct value immediately. To fix this, I suggest using a slightly different condition for rendering and setting the size. If the height or width is 0, we assume that the layout has not been calculated yet.

I tested this on a Redmi Note 11E Pro device in the release version. Expo: 52.0.36, RN: 0.77.1 

This probably eliminates the effect, not the cause. But since it's difficult to analyze because the bug is floating, I decided to propose such changes.

**before:**

https://github.com/user-attachments/assets/deeb5dab-1562-4dd6-a67d-3e578ee8b3eb

**after:**

https://github.com/user-attachments/assets/76f4e652-e59d-4f6c-805b-2f2fa35df1ae


<details>

<summary>My test code</summary>

```typescript
export default function AutoSizer({
  children,
}: {
  children: ({ width, height }: WidthAndHeight) => any
}) {
  const [layout, setLayout] = useState<WidthAndHeight | null>(null)
  
  const letLastMessageRef = useRef('')


  const onLayout = useCallback(
    (event: LayoutChangeEvent) => {
      const nl = event.nativeEvent.layout
      // https://github.com/necolas/react-native-web/issues/1704
      if (!layout || layout.width !== nl.width || layout.height !== nl.height) {
        setLayout({ width: nl.width, height: nl.height })
      }
      letLastMessageRef.current += `---- onLayout ----\n`
      letLastMessageRef.current += `l.w ${layout?.width} l.h ${layout?.height} nl.w ${nl.width} nl.h ${nl.height}\n`
      Alert.alert('onLayout', letLastMessageRef.current)
    },
    [layout, setLayout]
  )

  const isLayoutInizialized = layout && layout.height > 0 && layout.width > 0

  return (
    <View
      onLayout={onLayout}
      style={[sharedStyles.overflowHidden, sharedStyles.root, isLayoutInizialized && layout]}
    >
      {isLayoutInizialized ? children(layout) : null}
    </View>
  )
}
```

</details>