### PR TITLE
The calendar does not always scroll to the right side of the month when pressed on Android #459

### DIFF
--- a/src/Date/Swiper.native.tsx
+++ b/src/Date/Swiper.native.tsx
@@ -105,7 +105,7 @@ function SwiperInner({
       const contentOffset = e.nativeEvent.contentOffset
       const viewSize = e.nativeEvent.layoutMeasurement
       const newIndex = isHorizontal
-        ? Math.floor(contentOffset.x / viewSize.width)
+        ? Math.round(contentOffset.x / viewSize.width)
         : getIndexFromVerticalOffset(
             contentOffset.y - beginOffset,
             startWeekOnMonday


### PR DESCRIPTION
fix: #459 