### PR TITLE
Time input overflowing fix

### DIFF
--- a/src/Time/TimeInput.tsx
+++ b/src/Time/TimeInput.tsx
@@ -143,8 +143,8 @@ function TimeInput(
 
 const styles = StyleSheet.create({
   root: {
-    alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: "center",
+    paddingLeft: 10,
     width: 96,
   },
   input: {

--- a/src/Time/TimeInput.tsx
+++ b/src/Time/TimeInput.tsx
@@ -83,6 +83,7 @@ function TimeInput(
               : undefined,
           borderWidth: theme.isV3 && highlighted ? 2 : 0,
           height: inputType === inputTypes.keyboard ? 72 : 80,
+          paddingLeft: (Platform.OS === 'android' || Platform.OS === 'ios') ? 0 : 10,
         },
       ]}
     >
@@ -144,7 +145,6 @@ function TimeInput(
 const styles = StyleSheet.create({
   root: {
     justifyContent: "center",
-    paddingLeft: 10,
     width: 96,
   },
   input: {

--- a/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`renders TimeInput 1`] = `
     [
       {
         "justifyContent": "center",
-        "paddingLeft": 10,
         "width": 96,
       },
       {
@@ -15,6 +14,7 @@ exports[`renders TimeInput 1`] = `
         "borderRadius": 8,
         "borderWidth": 2,
         "height": 80,
+        "paddingLeft": 0,
       },
     ]
   }

--- a/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`renders TimeInput 1`] = `
   style={
     [
       {
-        "alignItems": "center",
         "justifyContent": "center",
+        "paddingLeft": 10,
         "width": 96,
       },
       {

--- a/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`renders TimeInputs 1`] = `
         [
           {
             "justifyContent": "center",
-            "paddingLeft": 10,
             "width": 96,
           },
           {
@@ -33,6 +32,7 @@ exports[`renders TimeInputs 1`] = `
             "borderRadius": 8,
             "borderWidth": 0,
             "height": 72,
+            "paddingLeft": 0,
           },
         ]
       }
@@ -173,7 +173,6 @@ exports[`renders TimeInputs 1`] = `
         [
           {
             "justifyContent": "center",
-            "paddingLeft": 10,
             "width": 96,
           },
           {
@@ -182,6 +181,7 @@ exports[`renders TimeInputs 1`] = `
             "borderRadius": 8,
             "borderWidth": 0,
             "height": 72,
+            "paddingLeft": 0,
           },
         ]
       }

--- a/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
@@ -23,8 +23,8 @@ exports[`renders TimeInputs 1`] = `
       style={
         [
           {
-            "alignItems": "center",
             "justifyContent": "center",
+            "paddingLeft": 10,
             "width": 96,
           },
           {
@@ -172,8 +172,8 @@ exports[`renders TimeInputs 1`] = `
       style={
         [
           {
-            "alignItems": "center",
             "justifyContent": "center",
+            "paddingLeft": 10,
             "width": 96,
           },
           {

--- a/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`renders TimePicker 1`] = `
           [
             {
               "justifyContent": "center",
-              "paddingLeft": 10,
               "width": 96,
             },
             {
@@ -41,6 +40,7 @@ exports[`renders TimePicker 1`] = `
               "borderRadius": 8,
               "borderWidth": 0,
               "height": 72,
+              "paddingLeft": 0,
             },
           ]
         }
@@ -181,7 +181,6 @@ exports[`renders TimePicker 1`] = `
           [
             {
               "justifyContent": "center",
-              "paddingLeft": 10,
               "width": 96,
             },
             {
@@ -190,6 +189,7 @@ exports[`renders TimePicker 1`] = `
               "borderRadius": 8,
               "borderWidth": 0,
               "height": 72,
+              "paddingLeft": 0,
             },
           ]
         }

--- a/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
@@ -31,8 +31,8 @@ exports[`renders TimePicker 1`] = `
         style={
           [
             {
-              "alignItems": "center",
               "justifyContent": "center",
+              "paddingLeft": 10,
               "width": 96,
             },
             {
@@ -180,8 +180,8 @@ exports[`renders TimePicker 1`] = `
         style={
           [
             {
-              "alignItems": "center",
               "justifyContent": "center",
+              "paddingLeft": 10,
               "width": 96,
             },
             {


### PR DESCRIPTION
<img width="855" alt="Screenshot 2025-05-05 at 4 34 54 PM" src="https://github.com/user-attachments/assets/cb0c8742-b5c8-43ef-950b-2cb400919f2d" />
Fixed the overflowing time input as shown in the below image.

<img width="603" alt="Screenshot 2025-05-05 at 4 35 33 PM" src="https://github.com/user-attachments/assets/51423627-62e9-47c6-85fe-c4a512702844" />
