### PR TITLE
Allow registering dynamic translations

### DIFF
--- a/docusaurus/docs/intro.md
+++ b/docusaurus/docs/intro.md
@@ -56,8 +56,8 @@ registerTranslation('pl', {
   selectRange: 'Select period',
   notAccordingToDateFormat: (inputFormat) =>
     `Date format must be ${inputFormat}`,
-  mustBeHigherThan: (date) => `Must be later then ${date}`,
-  mustBeLowerThan: (date) => `Must be earlier then ${date}`,
+  mustBeHigherThan: (date) => `Must be later than ${date}`,
+  mustBeLowerThan: (date) => `Must be earlier than ${date}`,
   mustBeBetween: (startDate, endDate) =>
     `Must be between ${startDate} - ${endDate}`,
   dateIsDisabled: 'Day is not allowed',
@@ -66,6 +66,35 @@ registerTranslation('pl', {
   typeInDate: 'Type in date',
   pickDateFromCalendar: 'Pick date from calendar',
   close: 'Close',
+})
+```
+
+### Dynamic
+
+React-Native-Paper-Dates also provides the ability to register dynamically resolved translations. This allows you to use a different translation provider to resolve the translations. For example:
+
+```javascript
+import { translate } from 'YOUR_TRANSLATION_PROVIDER'
+import { registerTranslation } from 'react-native-paper-dates'
+registerTranslation('dynamic', () => {
+  return {
+    save: translate('Save'),
+    selectSingle: translate('Select date'),
+    selectMultiple: translate('Select dates'),
+    selectRange: translate('Select period'),
+    notAccordingToDateFormat: (inputFormat) =>
+      translate(`Date format must be ${inputFormat}`),
+    mustBeHigherThan: (date) => translate(`Must be later than ${date}`),
+    mustBeLowerThan: (date) => translate(`Must be earlier than ${date}`),
+    mustBeBetween: (startDate, endDate) =>
+      translate(`Must be between ${startDate} - ${endDate}`),
+    dateIsDisabled: translate('Day is not allowed'),
+    previous: translate('Previous'),
+    next: translate('Next'),
+    typeInDate: translate('Type in date'),
+    pickDateFromCalendar: translate('Pick date from calendar'),
+    close: translate('Close'),
+  }
 })
 ```
 

--- a/src/translations/utils.ts
+++ b/src/translations/utils.ts
@@ -17,7 +17,14 @@ export type TranslationsType = {
   minute: string
 }
 
-let translationsPerLocale: Record<string, TranslationsType> = {}
+export type TranslationResolver = (
+  locale: string | undefined
+) => TranslationsType
+
+let translationsPerLocale: Record<
+  string,
+  TranslationsType | TranslationResolver
+> = {}
 
 export function getTranslation<K extends keyof TranslationsType>(
   locale: string | undefined,
@@ -32,7 +39,10 @@ export function getTranslation<K extends keyof TranslationsType>(
     )
     return fallback || key
   }
-  const translation = translationsPerLocale[l][key]
+  const translation: TranslationsType[K] =
+    typeof translationForLocale === 'function'
+      ? translationForLocale(locale)[key]
+      : translationForLocale[key]
   if (!translation) {
     console.warn(
       `[react-native-paper-dates] The locale ${locale} is registered, but ${key} is missing`
@@ -43,7 +53,7 @@ export function getTranslation<K extends keyof TranslationsType>(
 
 export function registerTranslation(
   locale: string,
-  translations: TranslationsType
+  translations: TranslationsType | TranslationResolver
 ) {
   translationsPerLocale[locale] = translations
 }


### PR DESCRIPTION
In some use cases, other i18n solutions manage translations. In these cases, it is desirable to resolve the translations dynamically.

For example, I use [tolgee](https://tolgee.io/) as a way to create and manage translations. It already deals with resolving the locale, and potentially pulling new translations from a remote server. As such, it is not feasible to know the translations at build or app start time, or even resolve them immediately without using a fallback.

This PR just adds a mechanism to provide a function to the `registerTranslation` function, which will be called when getting the translation.

In my application, this looks like this:
```typescript
import { registerTranslation } from 'react-native-paper-dates';
import { tolgee } from '@/services/tolgee';

registerTranslation('default', () => {
  const t = tolgee.t;
  return {
  // Note that if I created this object at app start, these dynamic values would not update or use tolgees fallback while it resolved them
    save: t('Save'),
    selectSingle: t('SelectDate'),
    selectMultiple: t('SelectDates'),
    selectRange: t('SelectPeriod'),
    notAccordingToDateFormat: (inputFormat) =>
      t(`DateFormatMustBe{inputFormat}`, { inputFormat: inputFormat }),
    mustBeHigherThan: (date) => t(`MustBeLaterThan{date}`, { date }),
    mustBeLowerThan: (date) => t(`MustBeEarlierThan{date}`, { date }),
    mustBeBetween: (startDate, endDate) =>
      t(`MustBeBetween{startDate}-{endDate}`, { startDate, endDate }),
    dateIsDisabled: t('DayIsNotAllowed'),
    previous: t('Previous'),
    next: t('Next'),
    typeInDate: t('TypeInDate'),
    pickDateFromCalendar: t('PickDateFromCalendar'),
    close: t('Close'),
    minute: t('Minute'),
    hour: t('Hour'),
  };
});

```