### PR TITLE
disableCalendarIcon prop for DatePickerInput

### DIFF
--- a/docusaurus/docs/date-picker/input-date-picker.md
+++ b/docusaurus/docs/date-picker/input-date-picker.md
@@ -39,57 +39,21 @@ View an interactive [Expo snack](https://snack.expo.dev/@fitzwabs/react-native-p
 
 ## Props
 
-**locale (Required)**  
-`Type: String`  
-A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de.
+**animationType**  
+`Type: 'slide' | 'fade' | 'none' | undefined`  
+The animation used when opening the date picker modal. Defaults to `'slide'`.
 
-**label (Required)**  
-`Type: String`  
-The label used to display in the component.
-
-**value (Required)**  
-`Type: Date | undefined`  
-The value used to populate the component.
-
-**inputMode (Required)**  
-`Type: String`  
-The type of input needed for the the picker component.
-
-**onChange**  
-`Type: Function`  
-Callback event when the component date mask length matches the text input length.
-
-**onChangeText**  
-`Type: Function`  
-Callback event when the component text input changes.
-
-**mode**  
-`Type: 'flat' | 'outlined'`  
-See [react-native-paper text-input](https://callstack.github.io/react-native-paper/text-input.html#mode).
-
-**iconSize**  
-`Type: Number`  
-Specifies the size of the icon in pixels.
-
-**iconColor**  
-`Type: String`  
-Sets the color of the icon.
-
-**iconStyle**  
-`Type: React.CSSProperties`  
-Defines the CSS styles for the icon element.
-
-**validRange**  
-`Type: {
-  startDate: Date | undefined,
-  endDate: Date | undefined,
-  disabledDates: Date[] | undefined
-}`  
-Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
-
-**withDateFormatInLabel**
+**disableCalendarIcon**  
 `Type: boolean | undefined`  
-Flag indicating if the date format should be inside the components label.
+Flag indicating if the calendar icon should be disabled. When set to `true`, the calendar icon will be disabled and users won't be able to click it to open the date picker modal. Defaults to `false`.
+
+**disableStatusBarPadding**  
+`Type: boolean | undefined`  
+Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+
+**endYear**  
+`Type: number | undefined`  
+The end year when the component is rendered. Defaults to `2200`.
 
 **hasError**  
 `Type: boolean | undefined`  
@@ -99,37 +63,49 @@ Flag indicating if the the component should display error styles.
 `Type: boolean | undefined`  
 Flag indicating if the the component should hide error styles along with the `helperText` component displaying the error message.
 
-**onValidationError**  
-`Type: Function | undefined`  
-Callback used to return any error messages from the components validation.
+**iconColor**  
+`Type: String`  
+Sets the color of the icon.
 
-**saveLabelDisabled**  
-`Type: boolean | undefined`  
-Flag indicating if the save label should be disabled and unable to receive events. Defaults to `false`.
+**iconSize**  
+`Type: Number`  
+Specifies the size of the icon in pixels.
 
-**uppercase**  
-`Type: boolean | undefined`  
-Flag indicating if the text in the component should be uppercase. Defaults to `true`.
-
-**startYear**  
-`Type: number | undefined`  
-The start year when the component is rendered. Defaults to `1800`.
-
-**endYear**  
-`Type: number | undefined`  
-The end year when the component is rendered. Defaults to `2200`.
-
-**startWeekOnMonday**  
-`Type: boolean | undefined`  
-Flag indicating if calendar grid sould show monday as the first column. Defaults to `false`.
+**iconStyle**  
+`Type: React.CSSProperties`  
+Defines the CSS styles for the icon element.
 
 **inputEnabled**  
 `Type: boolean | undefined`  
 Flag indicating if the component should be enabled or not. Behavior similarly to `disabled`. Defaults to `true`.
 
-**disableStatusBarPadding**  
-`Type: boolean | undefined`  
-Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+**inputMode (Required)**  
+`Type: String`  
+The type of input needed for the the picker component.
+
+**label (Required)**  
+`Type: String`  
+The label used to display in the component.
+
+**locale (Required)**  
+`Type: String`  
+A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de.
+
+**mode**  
+`Type: 'flat' | 'outlined'`  
+See [react-native-paper text-input](https://callstack.github.io/react-native-paper/text-input.html#mode).
+
+**onChange**  
+`Type: Function`  
+Callback event when the component date mask length matches the text input length.
+
+**onChangeText**  
+`Type: Function`  
+Callback event when the component text input changes.
+
+**onValidationError**  
+`Type: Function | undefined`  
+Callback used to return any error messages from the components validation.
 
 **presentationStyle**
 `Type: 'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'`
@@ -140,10 +116,38 @@ Determines the visual presentation style of the date picker modal. This prop all
 - `'formSheet'`: Renders the modal as a smaller form-style sheet.
 - `'overFullScreen'`: Overlays the modal on top of the content, allowing interaction with the underlying content.
 
-**animationType**  
-`Type: 'slide' | 'fade' | 'none' | undefined`  
-The animation used when opening the date picker modal. Defaults to `'slide'`.
-
 For example, if you set `presentationStyle` to `'pageSheet'`, the modal will be presented as a card-like sheet.
+
+**saveLabelDisabled**  
+`Type: boolean | undefined`  
+Flag indicating if the save label should be disabled and unable to receive events. Defaults to `false`.
+
+**startWeekOnMonday**  
+`Type: boolean | undefined`  
+Flag indicating if calendar grid sould show monday as the first column. Defaults to `false`.
+
+**startYear**  
+`Type: number | undefined`  
+The start year when the component is rendered. Defaults to `1800`.
+
+**uppercase**  
+`Type: boolean | undefined`  
+Flag indicating if the text in the component should be uppercase. Defaults to `true`.
+
+**validRange**  
+`Type: {
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  disabledDates: Date[] | undefined
+}`  
+Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
+
+**value (Required)**  
+`Type: Date | undefined`  
+The value used to populate the component.
+
+**withDateFormatInLabel**
+`Type: boolean | undefined`  
+Flag indicating if the date format should be inside the components label.
 
 - Other [react-native TextInput props](https://reactnative.dev/docs/textinput#props).\*

--- a/docusaurus/docs/date-picker/multiple-dates-picker.md
+++ b/docusaurus/docs/date-picker/multiple-dates-picker.md
@@ -55,6 +55,42 @@ View an interactive [Expo snack](https://snack.expo.dev/@fitzwabs/react-native-p
 
 ## Props
 
+**animationType**  
+`Type: String | undefined`  
+The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
+
+**calendarIcon**  
+`Type: string | undefined`  
+The edit icon used to toggle between input and calendar. Defaults to `calendar`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**closeIcon**  
+`Type: string | undefined`  
+The icon used to close the component. Defaults to `close`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**dates (Required)**  
+`Type: Date[]`  
+The date values used to populate the component.
+
+**disableStatusBarPadding**  
+`Type: boolean | undefined`  
+Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+
+**editIcon**  
+`Type: string | undefined`  
+The edit icon used to toggle between calendar and input. Defaults to `pencil`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**endLabel**  
+`Type: String | undefined`  
+The label used as the suffix to the ending date in the component. Defaults to `'To'`.
+
+**endYear**  
+`Type: number | undefined`  
+The end year when the component is rendered. Defaults to `2200`.
+
+**label**  
+`Type: String | undefined`  
+The label used as the header in the component. Defaults to `'Select date'`.
+
 **locale (Required)**  
 `Type: String`  
 A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de.
@@ -63,37 +99,21 @@ A locale can be composed of both a base language, the country (territory) of use
 `Type: 'single' | 'multiple' | 'range'`  
 The selection type for the date picker. For this example it is `"multiple"`.
 
-**visible (Required)**  
-`Type: boolean`  
-Flag indicating if the component should be displayed.
+**moreLabel**  
+`Type: String | undefined`  
+The label used display when multiple dates have been selected in the component. Defaults to `'More'`.
 
-**onDismiss (Required)**  
+**onChange**  
 `Type: Function`  
-The action to take when the component is closed.
-
-**dates (Required)**  
-`Type: Date[]`  
-The date values used to populate the component.
+Event handler when the component changes.
 
 **onConfirm (Required)**  
 `Type: Function`  
 The action to take when the date is selected.
 
-**moreLabel**  
-`Type: String | undefined`  
-The label used display when multiple dates have been selected in the component. Defaults to `'More'`.
-
-**validRange**  
-`Type: {
-  startDate: Date | undefined,
-  endDate: Date | undefined,
-  disabledDates: Date[] | undefined
-}`  
-Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
-
-**onChange**  
+**onDismiss (Required)**  
 `Type: Function`  
-Event handler when the component changes.
+The action to take when the component is closed.
 
 **saveLabel**  
 `Type: String | undefined`  
@@ -103,53 +123,33 @@ The label used confirm a date selection. Defaults to `'Save'`.
 `Type: boolean | undefined`  
 Flag indicating if the save label should be disabled and unable to receive events. Defaults to `false`.
 
-**uppercase**  
-`Type: boolean | undefined`  
-Flag indicating if the text in the component should be uppercase. Defaults to `true`.
-
-**label**  
-`Type: String | undefined`  
-The label used as the header in the component. Defaults to `'Select date'`.
-
 **startLabel**  
 `Type: String | undefined`  
 The label used as the prefix to the starting date in the component. Defaults to `'From'`.
-
-**endLabel**  
-`Type: String | undefined`  
-The label used as the suffix to the ending date in the component. Defaults to `'To'`.
-
-**animationType**  
-`Type: String | undefined`  
-The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
-
-**startYear**  
-`Type: number | undefined`  
-The start year when the component is rendered. Defaults to `1800`.
-
-**endYear**  
-`Type: number | undefined`  
-The end year when the component is rendered. Defaults to `2200`.
 
 **startWeekOnMonday**  
 `Type: boolean | undefined`  
 Flag indicating if calendar grid sould show monday as the first column. Defaults to `false`.
 
-**closeIcon**  
-`Type: string | undefined`  
-The icon used to close the component. Defaults to `close`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+**startYear**  
+`Type: number | undefined`  
+The start year when the component is rendered. Defaults to `1800`.
 
-**editIcon**  
-`Type: string | undefined`  
-The edit icon used to toggle between calendar and input. Defaults to `pencil`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
-
-**calendarIcon**  
-`Type: string | undefined`  
-The edit icon used to toggle between input and calendar. Defaults to `calendar`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
-
-**disableStatusBarPadding**  
+**uppercase**  
 `Type: boolean | undefined`  
-Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+Flag indicating if the text in the component should be uppercase. Defaults to `true`.
+
+**validRange**  
+`Type: {
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  disabledDates: Date[] | undefined
+}`  
+Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
+
+**visible (Required)**  
+`Type: boolean`  
+Flag indicating if the component should be displayed.
 
 **presentationStyle**
 `Type: 'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'`

--- a/docusaurus/docs/date-picker/range-date-picker.md
+++ b/docusaurus/docs/date-picker/range-date-picker.md
@@ -58,6 +58,46 @@ View an interactive [Expo snack](https://snack.expo.dev/@fitzwabs/react-native-p
 
 ## Props
 
+**animationType**  
+`Type: String | undefined`  
+The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
+
+**calendarIcon**  
+`Type: string | undefined`  
+The edit icon used to toggle between input and calendar. Defaults to `calendar`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**closeIcon**  
+`Type: string | undefined`  
+The icon used to close the component. Defaults to `close`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**disableStatusBarPadding**  
+`Type: boolean | undefined`  
+Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+
+**editIcon**  
+`Type: string | undefined`  
+The edit icon used to toggle between calendar and input. Defaults to `pencil`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**endDate (Required)**  
+`Type: Date`  
+The end date value used to populate the component.
+
+**endLabel**  
+`Type: String | undefined`  
+The label used as the suffix to the ending date in the component. Defaults to `'To'`.
+
+**endYear**  
+`Type: number | undefined`  
+The end year when the component is rendered. Defaults to `2200`.
+
+**inputEnabled**  
+`Type: boolean | undefined`  
+Flag indicating if the component should be enabled or not. Defaults to `true`.
+
+**label**  
+`Type: String | undefined`  
+The label used as the header in the component. Defaults to `'Select date'`.
+
 **locale (Required)**  
 `Type: String`  
 A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de.
@@ -66,37 +106,17 @@ A locale can be composed of both a base language, the country (territory) of use
 `Type: 'single' | 'multiple' | 'range'`  
 The selection type for the date picker. For this example it is `"range"`.
 
-**visible (Required)**  
-`Type: boolean`  
-Flag indicating if the component should be displayed.
-
-**onDismiss (Required)**  
+**onChange**  
 `Type: Function`  
-The action to take when the component is closed.
-
-**startDate (Required)**  
-`Type: Date`  
-The start date value used to populate the component.
-
-**endDate (Required)**  
-`Type: Date`  
-The end date value used to populate the component.
+Event handler when the component changes.
 
 **onConfirm (Required)**  
 `Type: Function`  
 The action to take when the date is selected.
 
-**validRange**  
-`Type: {
-  startDate: Date | undefined,
-  endDate: Date | undefined,
-  disabledDates: Date[] | undefined
-}`  
-Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
-
-**onChange**  
+**onDismiss (Required)**  
 `Type: Function`  
-Event handler when the component changes.
+The action to take when the component is closed.
 
 **saveLabel**  
 `Type: String | undefined`  
@@ -106,57 +126,37 @@ The label used confirm a date selection. Defaults to `'Save'`.
 `Type: boolean | undefined`  
 Flag indicating if the save label should be disabled and unable to receive events. Defaults to `false`.
 
-**uppercase**  
-`Type: boolean | undefined`  
-Flag indicating if the text in the component should be uppercase. Defaults to `true`.
-
-**label**  
-`Type: String | undefined`  
-The label used as the header in the component. Defaults to `'Select date'`.
+**startDate (Required)**  
+`Type: Date`  
+The start date value used to populate the component.
 
 **startLabel**  
 `Type: String | undefined`  
 The label used as the prefix to the starting date in the component. Defaults to `'From'`.
 
-**endLabel**  
-`Type: String | undefined`  
-The label used as the suffix to the ending date in the component. Defaults to `'To'`.
-
-**animationType**  
-`Type: String | undefined`  
-The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
+**startWeekOnMonday**  
+`Type: boolean | undefined`  
+Flag indicating if calendar grid sould show monday as the first column. Defaults to `false`.
 
 **startYear**  
 `Type: number | undefined`  
 The start year when the component is rendered. Defaults to `1800`.
 
-**endYear**  
-`Type: number | undefined`  
-The end year when the component is rendered. Defaults to `2200`.
-
-**startWeekOnMonday**  
+**uppercase**  
 `Type: boolean | undefined`  
-Flag indicating if calendar grid sould show monday as the first column. Defaults to `false`.
+Flag indicating if the text in the component should be uppercase. Defaults to `true`.
 
-**closeIcon**  
-`Type: string | undefined`  
-The icon used to close the component. Defaults to `close`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+**validRange**  
+`Type: {
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  disabledDates: Date[] | undefined
+}`  
+Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
 
-**editIcon**  
-`Type: string | undefined`  
-The edit icon used to toggle between calendar and input. Defaults to `pencil`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
-
-**calendarIcon**  
-`Type: string | undefined`  
-The edit icon used to toggle between input and calendar. Defaults to `calendar`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
-
-**inputEnabled**  
-`Type: boolean | undefined`  
-Flag indicating if the component should be enabled or not. Defaults to `true`.
-
-**disableStatusBarPadding**  
-`Type: boolean | undefined`  
-Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+**visible (Required)**  
+`Type: boolean`  
+Flag indicating if the component should be displayed.
 
 **presentationStyle**
 `Type: 'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'`

--- a/docusaurus/docs/date-picker/single-date-picker.md
+++ b/docusaurus/docs/date-picker/single-date-picker.md
@@ -57,6 +57,42 @@ View an interactive [Expo snack](https://snack.expo.dev/@fitzwabs/react-native-p
 
 ## Props
 
+**animationType**  
+`Type: String | undefined`  
+The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
+
+**calendarIcon**  
+`Type: string | undefined`  
+The edit icon used to toggle between input and calendar. Defaults to `calendar`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**closeIcon**  
+`Type: string | undefined`  
+The icon used to close the component. Defaults to `close`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**date (Required)**  
+`Type: Date`  
+The date value used to populate the component.
+
+**disableStatusBarPadding**  
+`Type: boolean | undefined`  
+Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+
+**editIcon**  
+`Type: string | undefined`  
+The edit icon used to toggle between calendar and input. Defaults to `pencil`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**endYear**  
+`Type: number | undefined`  
+The end year when the component is rendered. Defaults to `2200`.
+
+**inputEnabled**  
+`Type: boolean | undefined`  
+Flag indicating if the component should be enabled or not. Defaults to `true`.
+
+**label**  
+`Type: String | undefined`  
+The label used as the header in the component. Defaults to `'Select date'`.
+
 **locale (Required)**  
 `Type: String`  
 A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de.
@@ -65,33 +101,17 @@ A locale can be composed of both a base language, the country (territory) of use
 `Type: 'single' | 'multiple' | 'range'`  
 The selection type for the date picker. For this example it is `"single"`.
 
-**visible (Required)**  
-`Type: boolean`  
-Flag indicating if the component should be displayed.
-
-**onDismiss (Required)**  
+**onChange**  
 `Type: Function`  
-The action to take when the component is closed.
-
-**date (Required)**  
-`Type: Date`  
-The date value used to populate the component.
+Event handler when the component changes.
 
 **onConfirm (Required)**  
 `Type: Function`  
 The action to take when the date is selected.
 
-**validRange**  
-`Type: {
-  startDate: Date | undefined,
-  endDate: Date | undefined,
-  disabledDates: Date[] | undefined
-}`  
-Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
-
-**onChange**  
+**onDismiss (Required)**  
 `Type: Function`  
-Event handler when the component changes.
+The action to take when the component is closed.
 
 **saveLabel**  
 `Type: String | undefined`  
@@ -101,49 +121,29 @@ The label used confirm a date selection. Defaults to `'Save'`.
 `Type: boolean | undefined`  
 Flag indicating if the save label should be disabled and unable to receive events. Defaults to `false`.
 
-**uppercase**  
+**startWeekOnMonday**  
 `Type: boolean | undefined`  
-Flag indicating if the text in the component should be uppercase. Defaults to `true`.
-
-**label**  
-`Type: String | undefined`  
-The label used as the header in the component. Defaults to `'Select date'`.
-
-**animationType**  
-`Type: String | undefined`  
-The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
+Flag indicating if calendar grid sould show monday as the first column. Defaults to `false`.
 
 **startYear**  
 `Type: number | undefined`  
 The start year when the component is rendered. Defaults to `1800`.
 
-**endYear**  
-`Type: number | undefined`  
-The end year when the component is rendered. Defaults to `2200`.
-
-**startWeekOnMonday**  
+**uppercase**  
 `Type: boolean | undefined`  
-Flag indicating if calendar grid sould show monday as the first column. Defaults to `false`.
+Flag indicating if the text in the component should be uppercase. Defaults to `true`.
 
-**closeIcon**  
-`Type: string | undefined`  
-The icon used to close the component. Defaults to `close`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+**validRange**  
+`Type: {
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  disabledDates: Date[] | undefined
+}`  
+Limits which dates the user can navigate to and where events can go. Dates outside of the valid range will be grayed-out.
 
-**editIcon**  
-`Type: string | undefined`  
-The edit icon used to toggle between calendar and input. Defaults to `pencil`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
-
-**calendarIcon**  
-`Type: string | undefined`  
-The edit icon used to toggle between input and calendar. Defaults to `calendar`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
-
-**inputEnabled**  
-`Type: boolean | undefined`  
-Flag indicating if the component should be enabled or not. Defaults to `true`.
-
-**disableStatusBarPadding**  
-`Type: boolean | undefined`  
-Flag indicating if the status bar padding should be enabled or not. Defaults to `false`.
+**visible (Required)**  
+`Type: boolean`  
+Flag indicating if the component should be displayed.
 
 **presentationStyle**
 `Type: `'overFullScreen' | 'pageSheet' | undefined`

--- a/docusaurus/docs/time-picker.md
+++ b/docusaurus/docs/time-picker.md
@@ -54,66 +54,66 @@ View an interactive [Expo snack](https://snack.expo.dev/@fitzwabs/react-native-p
 
 ## Props
 
-**locale (Required)**  
-`Type: String`  
-A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de.
-
-**visible (Required)**  
-`Type: boolean`  
-Flag indicating if the component should be displayed.
-
-**onDismiss (Required)**  
-`Type: Function`  
-The action to take when the component is closed.
-
-**onConfirm (Required)**  
-`Type: Function`  
-The action to take when the date is selected.
-
-**hours**  
-`Type: number | undefined`  
-The hours values used to populate the component. Defaults to the current hour.
-
-**minutes**  
-`Type: number | undefined`  
-The minutes values used to populate the component. Defaults to the current minutes.
-
-**label**  
+**animationType**  
 `Type: String | undefined`  
-The label used as the header in the component. Defaults to `'Select time'`.
-
-**uppercase**  
-`Type: boolean | undefined`  
-Flag indicating if the text in the component should be uppercase. Defaults to `true`.
+The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
 
 **cancelLabel**  
 `Type: String | undefined`  
 The label that will close the component. Defaults to `'Cancel'`.
 
-**confirmLabel**  
-`Type: String | undefined`  
-The label that will confirm the component selection. Defaults to `'Ok'`.
-
-**animationType**  
-`Type: String | undefined`  
-The animation used when opening the component. Defaults to `'slide'` on ios/android and `'none'` on web.
-
-**keyboardIcon**  
-`Type: string | undefined`  
-The icon used to toggle between the OS input. Defaults to `keyboard-outline`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
-
 **clockIcon**  
 `Type: string | undefined`  
 The icon used to toggle between time picker and input. Defaults to `clock-outline`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
 
-**use24HourClock**
-`Type: boolean | undefined`
-Flag indicating if the time input should use the 24 hours clock. Defaults to the system clock.
+**confirmLabel**  
+`Type: String | undefined`  
+The label that will confirm the component selection. Defaults to `'Ok'`.
+
+**defaultInputType**
+`Type: 'picker' | 'keyboard'`
+Which input type to use by default. Defaults to the clock-face picker.
+
+**hours**  
+`Type: number | undefined`  
+The hours values used to populate the component. Defaults to the current hour.
 
 **inputFontSize**
 `Type: number | undefined`
 Font size of the time input. Defaults to 57. Useful when using a custom font.
 
-**defaultInputType**
-`Type: 'picker' | 'keyboard'`
-Which input type to use by default. Defaults to the clock-face picker.
+**keyboardIcon**  
+`Type: string | undefined`  
+The icon used to toggle between the OS input. Defaults to `keyboard-outline`. You can pass the name of an icon from [MaterialCommunityIcons](https://materialdesignicons.com/).
+
+**label**  
+`Type: String | undefined`  
+The label used as the header in the component. Defaults to `'Select time'`.
+
+**locale (Required)**  
+`Type: String`  
+A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de.
+
+**minutes**  
+`Type: number | undefined`  
+The minutes values used to populate the component. Defaults to the current minutes.
+
+**onConfirm (Required)**  
+`Type: Function`  
+The action to take when the date is selected.
+
+**onDismiss (Required)**  
+`Type: Function`  
+The action to take when the component is closed.
+
+**uppercase**  
+`Type: boolean | undefined`  
+Flag indicating if the text in the component should be uppercase. Defaults to `true`.
+
+**use24HourClock**
+`Type: boolean | undefined`
+Flag indicating if the time input should use the 24 hours clock. Defaults to the system clock.
+
+**visible (Required)**  
+`Type: boolean`  
+Flag indicating if the component should be displayed.

--- a/src/Date/DatePickerInput.shared.tsx
+++ b/src/Date/DatePickerInput.shared.tsx
@@ -14,6 +14,7 @@ export type DatePickerInputProps = {
   hasError?: boolean
   onValidationError?: ((error: string | null) => void) | undefined
   calendarIcon?: string
+  disableCalendarIcon?: boolean
   iconSize?: number
   iconStyle?: CSSProperties
   iconColor?: string

--- a/src/Date/DatePickerInput.tsx
+++ b/src/Date/DatePickerInput.tsx
@@ -11,6 +11,7 @@ function DatePickerInput(
   {
     withModal = true,
     calendarIcon = 'calendar',
+    disableCalendarIcon = false,
     animationType = Platform.select({ web: 'none', default: 'slide' }),
     presentationStyle = 'overFullScreen',
     ...rest
@@ -44,7 +45,7 @@ function DatePickerInput(
             icon={calendarIcon}
             color={rest.iconColor ?? undefined}
             forceTextInputFocus={false}
-            disabled={rest.disabled}
+            disabled={rest.disabled || disableCalendarIcon}
             onPress={() => setVisible(true)}
             style={rest.iconStyle as StyleProp<ViewStyle>}
             testID={`${rest.testID || 'date-picker'}-icon-button`}

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -265,7 +265,7 @@ exports[`renders CalendarEdit 1`] = `
             }
             testID="text-input-flat"
             underlineColorAndroid="transparent"
-            value="06/06/2025"
+            value="06/08/2025"
             withModal={false}
           />
         </View>

--- a/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
@@ -258,7 +258,7 @@ exports[`renders DatePickerInput 1`] = `
             }
             testID="text-input-flat"
             underlineColorAndroid="transparent"
-            value="06/06/2025"
+            value="06/08/2025"
           />
         </View>
         <View

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`renders DatePickerInputWithoutModal 1`] = `
           }
           testID="text-input-flat"
           underlineColorAndroid="transparent"
-          value="06/06/2025"
+          value="06/08/2025"
         />
       </View>
     </View>


### PR DESCRIPTION
# Motivation

This introduces a new `disableCalendarIcon` prop that defaults to `false` for the `DatePickerInput` that can be used and while updating the docs I alphabetized the props for the other component documentation files to improve readability. 