### PR TITLE
refactor: fix overflow issue on time picker modal

### DIFF
--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -273,7 +273,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.34,
     shadowRadius: 6.27,
     elevation: 3,
-    minWidth: 287,
+    minWidth: 328,
     paddingVertical: 8,
   },
   timePickerContainer: {

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -265,7 +265,7 @@ exports[`renders CalendarEdit 1`] = `
             }
             testID="text-input-flat"
             underlineColorAndroid="transparent"
-            value="08/07/2025"
+            value="09/05/2025"
             withModal={false}
           />
         </View>

--- a/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
@@ -258,7 +258,7 @@ exports[`renders DatePickerInput 1`] = `
             }
             testID="text-input-flat"
             underlineColorAndroid="transparent"
-            value="08/07/2025"
+            value="09/05/2025"
           />
         </View>
         <View

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`renders DatePickerInputWithoutModal 1`] = `
           }
           testID="text-input-flat"
           underlineColorAndroid="transparent"
-          value="08/07/2025"
+          value="09/05/2025"
         />
       </View>
     </View>


### PR DESCRIPTION
- Fixes https://github.com/web-ridge/react-native-paper-dates/issues/487#issue-3249930565 by updating min width to account for am/pm selector.
- Fixes the broken tests in https://github.com/web-ridge/react-native-paper-dates/pull/496 so we can close that. Thanks @newclarityex 😎 