### PR TITLE
Corrected color of save button label in theme V3

### DIFF
--- a/src/Date/DatePickerModalHeader.tsx
+++ b/src/Date/DatePickerModalHeader.tsx
@@ -44,7 +44,7 @@ export default function DatePickerModalHeader(
             testID="react-native-paper-dates-close"
           />
           <Button
-            textColor={theme.isV3 ? theme.colors.primary : color}
+            textColor={theme.isV3 ? theme.colors.onPrimary : color}
             onPress={props.onSave}
             disabled={props.saveLabelDisabled ?? false}
             uppercase={props.uppercase ?? true}

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders AnimatedCrossView 1`] = `
 <View

--- a/src/__tests__/Date/__snapshots__/AutoSize.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AutoSize.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders AutoSizer 1`] = `
 <View

--- a/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders Calendar 1`] = `
 <View

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders CalendarEdit 1`] = `
 <View
@@ -264,7 +264,7 @@ exports[`renders CalendarEdit 1`] = `
             }
             testID="text-input-flat"
             underlineColorAndroid="transparent"
-            value="12/19/2025"
+            value="01/03/2026"
             withModal={false}
           />
         </View>

--- a/src/__tests__/Date/__snapshots__/CalendarHeader.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarHeader.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders CalendarHeader 1`] = `
 <View

--- a/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DatePickerInput 1`] = `
 [
@@ -257,7 +257,7 @@ exports[`renders DatePickerInput 1`] = `
             }
             testID="text-input-flat"
             underlineColorAndroid="transparent"
-            value="12/19/2025"
+            value="01/03/2026"
           />
         </View>
         <View

--- a/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerInputWithoutModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DatePickerInputWithoutModal 1`] = `
 <View
@@ -255,7 +255,7 @@ exports[`renders DatePickerInputWithoutModal 1`] = `
           }
           testID="text-input-flat"
           underlineColorAndroid="transparent"
-          value="12/19/2025"
+          value="01/03/2026"
         />
       </View>
     </View>

--- a/src/__tests__/Date/__snapshots__/DatePickerModal.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DatePickerModal 1`] = `
 <RNCSafeAreaProvider

--- a/src/__tests__/Date/__snapshots__/DatePickerModalContent.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerModalContent.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DatePickerModalContent 1`] = `
 <RNCSafeAreaProvider

--- a/src/__tests__/Date/__snapshots__/DatePickerModalHeader.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerModalHeader.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DatePickerModalHeader 1`] = `
 <RNCSafeAreaProvider

--- a/src/__tests__/Date/__snapshots__/DatePickerModalHeaderBackground.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DatePickerModalHeaderBackground.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DatePickerModalHeaderBackground 1`] = `
 <RNCSafeAreaProvider

--- a/src/__tests__/Date/__snapshots__/DayName.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DayName.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DayName 1`] = `
 <View

--- a/src/__tests__/Date/__snapshots__/DayNames.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DayNames.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DayNames 1`] = `
 <View

--- a/src/__tests__/Date/__snapshots__/DayRange.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DayRange.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders DayRange 1`] = `
 <View

--- a/src/__tests__/Time/__snapshots__/AmPmSwitcher.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AmPmSwitcher.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders AmPmSwitcher 1`] = `
 <View

--- a/src/__tests__/Time/__snapshots__/AnalogClock.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AnalogClock.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders AnalogClock 1`] = `
 <View

--- a/src/__tests__/Time/__snapshots__/AnalogClockHours.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AnalogClockHours.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders AnalogClockHours 1`] = `
 [

--- a/src/__tests__/Time/__snapshots__/AnalogClockMinutes.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AnalogClockMinutes.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders AnalogClockMinutes 1`] = `
 [

--- a/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders TimeInput 1`] = `
 <View

--- a/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders TimeInputs 1`] = `
 <View

--- a/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders TimePicker 1`] = `
 <View


### PR DESCRIPTION
# Description of the change
I Changed the color of the text of the save button to be onPrimary instead of primary, as that caused the button to have the same color as the background, essentially rendering it invisible on all platforms.

# Consequences
I had to create new test snapshots but otherwise this solved the issue.