### PR TITLE
fix: use dark scrollbar in dark mode on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.23.6",
+  "version": "0.23.7",
   "author": "Richard Lindhout <info@webridge.nl> (https://github.com/web-ridge)",
   "bugs": {
     "url": "https://github.com/web-ridge/react-native-paper-dates/issues"

--- a/src/Date/Swiper.tsx
+++ b/src/Date/Swiper.tsx
@@ -1,4 +1,5 @@
 import { View } from 'react-native'
+import { useTheme } from 'react-native-paper'
 import {
   getIndexFromVerticalOffset,
   getMonthHeight,
@@ -161,6 +162,7 @@ function VerticalScroller({
     visibleArray(constrainedInitialIndex)
   )
 
+  const theme = useTheme()
   const idx = useRef<number>(constrainedInitialIndex)
   const parentRef = useRef<HTMLDivElement | null>(null)
 
@@ -229,6 +231,7 @@ function VerticalScroller({
         height,
         width,
         overflow: 'auto',
+        colorScheme: theme.dark ? 'dark' : 'light',
       }}
       onScroll={onScroll}
     >


### PR DESCRIPTION
## Problem
The vertical calendar scrollbar on web always rendered with the browser's default light appearance, even in dark mode. This adds colorScheme to the scroll container in Swiper.tsx so the browser uses a dark scrollbar when the Paper theme is dark.

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/0c4f881c-cfba-4f60-9707-4e1f72249006" width="300" /> | <video src="https://github.com/user-attachments/assets/8db488cd-c801-4e2c-acee-95298d4edd99" width="300" /> |






