### PR TITLE
fix: unblock releases — drop publishConfig.registry (npm 12 EUNKNOWNCONFIG)

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,9 +119,6 @@
     "useTabs": false,
     "semi": false
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "react-native": "src/index",
   "react-native-builder-bob": {
     "source": "src",


### PR DESCRIPTION
## Problem

No release has published since the OIDC migration (#526/b90cdc7). Every `release` job on `master` fails at `npm publish`:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flag:
npm error   - --//registry.npmjs.org/ (registry https://registry.npmjs.org/)
```

## Root cause

1. `package.json` set `publishConfig.registry`.
2. release-it (19.2.4) turns that into a **single argv token** `--registry https://registry.npmjs.org/` when it spawns `npm publish` (verified by capturing the child argv).
3. The release job's `npm install -g npm@latest` now installs **npm 12**, which made unknown CLI flags a hard error. npm parses that one token as a config key, splits on `:`, gets base-key `//registry.npmjs.org/`, doesn't recognize it → `EUNKNOWNCONFIG`. npm ≤ 11 only warned, which is why it worked before the npm bump.

Reproduced the exact error locally on npm 12.0.1 with release-it's real argv, and confirmed removing the field publishes cleanly.

## Fix

Remove `publishConfig.registry`. npm's default registry is already `registry.npmjs.org`, and OIDC trusted publishing (already configured for this repo + `ci.yml`) auto-generates provenance, so the field is unnecessary. release-it now emits a clean `npm publish . --tag latest --workspaces=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)