### PR TITLE
fix: deploy example from dist after Metro web export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'eu-central-1'
-          SOURCE_DIR: 'example/web-build'      # optional: defaults to entire repository
+          SOURCE_DIR: 'example/dist'      # optional: defaults to entire repository
 
 
 


### PR DESCRIPTION
## Summary
As I anticipated. I wasn't able to verify the example app would successfully deploy. This should address the following

- Update the `deploy-example` job `SOURCE_DIR` from `example/web-build` to `example/dist`
- Aligns S3 deploy with the current `expo export --platform web` output path after the Metro web migration