### PR TITLE
Date picker color updates

### DIFF
--- a/src/Date/AnimatedCrossView.tsx
+++ b/src/Date/AnimatedCrossView.tsx
@@ -58,7 +58,7 @@ export default function AnimatedCrossView({
         style={[
           styles.calendarEdit,
           {
-            backgroundColor: theme.colors.surface,
+            backgroundColor: theme.colors.elevation.level3,
             opacity: calendarOpacity.current.interpolate({
               inputRange: [0, 1],
               outputRange: [1, 0],

--- a/src/Date/CalendarEdit.tsx
+++ b/src/Date/CalendarEdit.tsx
@@ -10,6 +10,7 @@ import type { LocalState } from './DatePickerModalContent'
 
 import DatePickerInputWithoutModal from './DatePickerInputWithoutModal'
 import { memo, useCallback, useEffect, useRef } from 'react'
+import { useTheme } from 'react-native-paper'
 import { sharedStyles } from '../shared/styles'
 
 function CalendarEdit({
@@ -39,9 +40,11 @@ function CalendarEdit({
   withDateFormatInLabel?: boolean
   placeholder?: string
 }) {
+  const theme = useTheme()
   const dateInput = useRef<TextInputNative | null>(null)
   const startInput = useRef<TextInputNative | null>(null)
   const endInput = useRef<TextInputNative | null>(null)
+  const inputStyle = { backgroundColor: theme.colors.elevation.level3 }
 
   // when switching views focus, or un-focus text input
   useEffect(() => {
@@ -99,6 +102,7 @@ function CalendarEdit({
           inputEnabled={inputEnabled}
           withDateFormatInLabel={withDateFormatInLabel}
           placeholder={placeholder}
+          style={inputStyle}
         />
       ) : null}
       {mode === 'range' ? (
@@ -119,6 +123,7 @@ function CalendarEdit({
             inputEnabled={inputEnabled}
             withDateFormatInLabel={withDateFormatInLabel}
             placeholder={placeholder}
+            style={inputStyle}
           />
           <View style={styles.separator} />
           <DatePickerInputWithoutModal
@@ -136,6 +141,7 @@ function CalendarEdit({
             inputEnabled={inputEnabled}
             withDateFormatInLabel={withDateFormatInLabel}
             placeholder={placeholder}
+            style={inputStyle}
           />
         </View>
       ) : null}

--- a/src/Date/CalendarHeader.tsx
+++ b/src/Date/CalendarHeader.tsx
@@ -46,7 +46,7 @@ function CalendarHeader({
       {isHorizontal ? (
         <View style={styles.buttonContainer} pointerEvents={'box-none'}>
           <View style={sharedStyles.root} pointerEvents={'box-none'} />
-          <View style={{ backgroundColor: theme.colors.surface }}>
+          <View style={{ backgroundColor: theme.colors.elevation.level3 }}>
             <IconButton
               icon="chevron-left"
               accessibilityLabel={getTranslation(locale, 'previous')}
@@ -54,7 +54,7 @@ function CalendarHeader({
               testID="react-native-paper-dates-prev-month"
             />
           </View>
-          <View style={{ backgroundColor: theme.colors.surface }}>
+          <View style={{ backgroundColor: theme.colors.elevation.level3 }}>
             <IconButton
               icon="chevron-right"
               accessibilityLabel={getTranslation(locale, 'next')}

--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -106,7 +106,7 @@ export function DatePickerModal(
           <View
             style={[
               styles.modalContent,
-              { backgroundColor: theme.colors.surface },
+              { backgroundColor: theme.colors.elevation.level3 },
               dimensions.width > 650
                 ? useFormSheet
                   ? styles.modalContentFormSheet

--- a/src/Date/DayName.tsx
+++ b/src/Date/DayName.tsx
@@ -13,7 +13,7 @@ function DayName({ label }: { label: string }) {
         maxFontSizeMultiplier={1.5}
         style={[
           styles.dayNameLabel,
-          { ...textFont, color: theme.colors.onSurface },
+          { ...textFont, color: theme.colors.onSurfaceVariant },
         ]}
         selectable={false}
       >
@@ -30,7 +30,6 @@ const styles = StyleSheet.create({
   },
   dayNameLabel: {
     fontSize: 14,
-    opacity: 0.7,
   },
 })
 

--- a/src/Date/DayNames.tsx
+++ b/src/Date/DayNames.tsx
@@ -53,7 +53,6 @@ function DayNames({
 const styles = StyleSheet.create({
   dayNames: {
     alignItems: 'center',
-    backgroundColor: '#fff',
     flexDirection: 'row',
     height: dayNamesHeight,
   },

--- a/src/Date/DayNames.tsx
+++ b/src/Date/DayNames.tsx
@@ -39,7 +39,7 @@ function DayNames({
 
   return (
     <View
-      style={[styles.dayNames, { backgroundColor: theme.colors.surface }]}
+      style={[styles.dayNames, { backgroundColor: theme.colors.elevation.level3 }]}
       pointerEvents="none"
     >
       {shortDayNames

--- a/src/Date/DayNames.tsx
+++ b/src/Date/DayNames.tsx
@@ -39,7 +39,10 @@ function DayNames({
 
   return (
     <View
-      style={[styles.dayNames, { backgroundColor: theme.colors.elevation.level3 }]}
+      style={[
+        styles.dayNames,
+        { backgroundColor: theme.colors.elevation.level3 },
+      ]}
       pointerEvents="none"
     >
       {shortDayNames

--- a/src/Date/YearPicker.tsx
+++ b/src/Date/YearPicker.tsx
@@ -44,7 +44,7 @@ export default function YearPicker({
       style={[
         StyleSheet.absoluteFill,
         styles.root,
-        { backgroundColor: theme.colors.surface },
+        { backgroundColor: theme.colors.elevation.level3 },
         selectingYear ? sharedStyles.opacity1 : sharedStyles.opacity0,
       ]}
       pointerEvents={selectingYear ? 'auto' : 'none'}

--- a/src/Time/AmPmSwitcher.tsx
+++ b/src/Time/AmPmSwitcher.tsx
@@ -9,29 +9,38 @@ export default function AmPmSwitcher({
   onChange,
   hours,
   inputType,
+  direction = 'vertical',
 }: {
   hours: number
   onChange: (newHours: number) => any
   inputType: PossibleInputTypes
+  direction?: 'vertical' | 'horizontal'
 }) {
   const theme = useTheme()
 
   const { setMode, mode } = useContext(DisplayModeContext)
 
   const backgroundColor = theme.colors.outline
-
+  const isHorizontal = direction === 'horizontal'
   const isAM = mode === 'AM'
+
+  const height = isHorizontal
+    ? 38
+    : inputType === inputTypes.keyboard
+      ? 72
+      : 80
 
   return (
     <View
       style={[
-        styles.root,
+        isHorizontal ? styles.rootHorizontal : styles.rootVertical,
         // eslint-disable-next-line react-native/no-inline-styles
         {
           borderColor: backgroundColor,
           borderRadius: theme.roundness * 2,
-          height: inputType === inputTypes.keyboard ? 72 : 80,
-          marginBottom: inputType === 'keyboard' ? 16 : 0,
+          height,
+          marginBottom:
+            !isHorizontal && inputType === inputTypes.keyboard ? 16 : 0,
         },
       ]}
     >
@@ -46,7 +55,12 @@ export default function AmPmSwitcher({
         selected={isAM}
         disabled={isAM}
       />
-      <View style={[styles.switchSeparator, { backgroundColor }]} />
+      <View
+        style={[
+          isHorizontal ? styles.separatorHorizontal : styles.separatorVertical,
+          { backgroundColor },
+        ]}
+      />
       <SwitchButton
         label="PM"
         onPress={() => {
@@ -111,14 +125,24 @@ function SwitchButton({
 }
 
 const styles = StyleSheet.create({
-  root: {
+  rootVertical: {
     width: 52,
     borderWidth: 1,
     overflow: 'hidden',
   },
-  switchSeparator: {
+  rootHorizontal: {
+    width: 216,
+    flexDirection: 'row',
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  separatorVertical: {
     height: 1,
     width: 52,
+  },
+  separatorHorizontal: {
+    width: 1,
+    alignSelf: 'stretch',
   },
   switchButtonInner: {
     flex: 1,

--- a/src/Time/AmPmSwitcher.tsx
+++ b/src/Time/AmPmSwitcher.tsx
@@ -24,11 +24,7 @@ export default function AmPmSwitcher({
   const isHorizontal = direction === 'horizontal'
   const isAM = mode === 'AM'
 
-  const height = isHorizontal
-    ? 38
-    : inputType === inputTypes.keyboard
-      ? 72
-      : 80
+  const height = isHorizontal ? 38 : inputType === inputTypes.keyboard ? 72 : 80
 
   return (
     <View

--- a/src/Time/TimeInputs.tsx
+++ b/src/Time/TimeInputs.tsx
@@ -8,6 +8,7 @@ import { Text, useTheme } from 'react-native-paper'
 
 import {
   clockTypes,
+  inputTypes,
   PossibleClockTypes,
   PossibleInputTypes,
   toHourInputFormat,
@@ -52,6 +53,8 @@ function TimeInputs({
   const endInput = useRef<TextInputNative | null>(null)
   const dimensions = useWindowDimensions()
   const isLandscape = dimensions.width > dimensions.height
+  const useHorizontalAmPm =
+    !is24Hour && isLandscape && inputType === inputTypes.picker
   const minutesRef = useLatest(minutes)
 
   const onSubmitStartInput = useCallback(() => {
@@ -75,8 +78,8 @@ function TimeInputs({
     [onChange, minutesRef]
   )
 
-  return (
-    <View style={[styles.inputContainer, isLandscape && sharedStyles.root]}>
+  const hourMinuteRow = (
+    <View style={styles.inputContainer}>
       <View style={styles.column}>
         <TimeInput
           ref={startInput}
@@ -178,18 +181,37 @@ function TimeInputs({
           </Text>
         ) : null}
       </View>
-      {!is24Hour && (
+      {!is24Hour && !useHorizontalAmPm ? (
         <>
           <View style={styles.spaceBetweenInputsAndSwitcher} />
           <AmPmSwitcher
             hours={hours}
             onChange={onChangeHours}
             inputType={inputType}
+            direction="vertical"
           />
         </>
-      )}
+      ) : null}
     </View>
   )
+
+  if (useHorizontalAmPm) {
+    return (
+      <View style={styles.landscapeColumn}>
+        {hourMinuteRow}
+        <View style={styles.landscapeSwitcherSpacing}>
+          <AmPmSwitcher
+            hours={hours}
+            onChange={onChangeHours}
+            inputType={inputType}
+            direction="horizontal"
+          />
+        </View>
+      </View>
+    )
+  }
+
+  return hourMinuteRow
 }
 
 const styles = StyleSheet.create({
@@ -212,6 +234,13 @@ const styles = StyleSheet.create({
   inputContainer: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  landscapeColumn: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+  landscapeSwitcherSpacing: {
+    marginTop: 16,
   },
   spaceBetweenInputsAndSwitcher: {
     width: 12,

--- a/src/Time/TimePicker.tsx
+++ b/src/Time/TimePicker.tsx
@@ -84,6 +84,18 @@ function TimePicker({
     [onChange, hours, is24Hour]
   )
 
+  const inputsWidth =
+    96 * 2 +
+    24 +
+    (is24Hour || (isLandscape && inputType === inputTypes.picker)
+      ? 0
+      : 12 + 52)
+
+  const clockWidth =
+    inputType === inputTypes.picker
+      ? circleSize + (isLandscape ? 64 : 0)
+      : 0
+
   return (
     <DisplayModeContext.Provider
       value={{ mode: displayMode, setMode: setDisplayMode }}
@@ -91,18 +103,7 @@ function TimePicker({
       <View
         style={
           isLandscape
-            ? [
-                styles.rootLandscape,
-                {
-                  width:
-                    24 * 3 +
-                    96 * 2 +
-                    52 +
-                    (inputType === inputTypes.picker
-                      ? circleSize
-                      : -circleSize),
-                },
-              ]
+            ? [styles.rootLandscape, { width: inputsWidth + clockWidth }]
             : styles.rootPortrait
         }
       >
@@ -118,7 +119,12 @@ function TimePicker({
           locale={locale}
         />
         {inputType === inputTypes.picker ? (
-          <View style={styles.clockContainer}>
+          <View
+            style={[
+              styles.clockContainer,
+              isLandscape && styles.clockContainerLandscape,
+            ]}
+          >
             <AnalogClock
               hours={toHourInputFormat(hours, is24Hour)}
               minutes={minutes}
@@ -138,6 +144,11 @@ const styles = StyleSheet.create({
     paddingTop: 36,
     paddingLeft: 12,
     paddingRight: 12,
+  },
+  clockContainerLandscape: {
+    paddingTop: 0,
+    paddingLeft: 64,
+    paddingRight: 0,
   },
   rootLandscape: {
     flexDirection: 'row',

--- a/src/Time/TimePicker.tsx
+++ b/src/Time/TimePicker.tsx
@@ -87,14 +87,10 @@ function TimePicker({
   const inputsWidth =
     96 * 2 +
     24 +
-    (is24Hour || (isLandscape && inputType === inputTypes.picker)
-      ? 0
-      : 12 + 52)
+    (is24Hour || (isLandscape && inputType === inputTypes.picker) ? 0 : 12 + 52)
 
   const clockWidth =
-    inputType === inputTypes.picker
-      ? circleSize + (isLandscape ? 64 : 0)
-      : 0
+    inputType === inputTypes.picker ? circleSize + (isLandscape ? 64 : 0) : 0
 
   return (
     <DisplayModeContext.Provider

--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -104,9 +104,7 @@ export function TimePickerModal({
     labelText = 'Enter time'
   }
 
-  const color = theme.dark
-    ? theme.colors.elevation.level3
-    : theme.colors.surface
+  const color = theme.colors.elevation.level3
 
   return (
     <Modal

--- a/src/Time/TimePickerModal.tsx
+++ b/src/Time/TimePickerModal.tsx
@@ -138,6 +138,10 @@ export function TimePickerModal({
                 {
                   backgroundColor: color,
                   borderRadius: 28,
+                  minWidth: inputType === inputTypes.picker ? 328 : 280,
+                  ...(inputType === inputTypes.keyboard
+                    ? { height: 252 }
+                    : null),
                 },
               ]}
             >
@@ -170,7 +174,7 @@ export function TimePickerModal({
               </View>
               <View style={styles.bottom}>
                 <IconButton
-                  iconColor={theme.colors.onBackground}
+                  iconColor={theme.colors.onSurface}
                   icon={getTimeInputTypeIcon(inputType, {
                     keyboard: keyboardIcon,
                     picker: clockIcon,
@@ -218,7 +222,8 @@ const styles = StyleSheet.create({
   bottom: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 8,
+    paddingHorizontal: 24,
+    paddingVertical: 8,
   },
   center: {
     justifyContent: 'center',
@@ -226,7 +231,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   inputTypeToggle: {
-    margin: 4,
+    margin: 0,
   },
   labelContainer: {
     justifyContent: 'flex-end',
@@ -247,8 +252,8 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.34,
     shadowRadius: 6.27,
     elevation: 3,
-    minWidth: 328,
     paddingVertical: 8,
+    justifyContent: 'space-between',
   },
   timePickerContainer: {
     paddingLeft: 24,

--- a/src/Time/timeUtils.ts
+++ b/src/Time/timeUtils.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useTheme } from 'react-native-paper'
 
 export const circleSize = 256
@@ -155,55 +154,25 @@ export function getAngle(left: number, top: number, size: number) {
 
 export function useSwitchColors(highlighted: boolean) {
   const theme = useTheme()
-  const backgroundColor = useMemo<string>(() => {
-    if (theme.dark) {
-      if (highlighted) {
-        return theme.colors.tertiaryContainer
-      }
-      return theme.colors.backdrop
-    }
-
-    if (highlighted) {
-      return theme.colors.primaryContainer
-    }
-    return theme.colors.surface
-  }, [highlighted, theme])
-
-  const color = useMemo<string>(() => {
-    if (highlighted && !theme.dark) {
-      return theme.colors.onSurfaceVariant
-    }
-    if (highlighted && theme.dark) {
-      return theme.colors.onTertiaryContainer
-    }
-    return theme.colors.onSurfaceVariant
-  }, [highlighted, theme])
+  const backgroundColor = highlighted
+    ? theme.colors.tertiaryContainer
+    : 'transparent'
+  const color = highlighted
+    ? theme.colors.onTertiaryContainer
+    : theme.colors.onSurfaceVariant
 
   return { backgroundColor, color }
 }
 
 export function useInputColors(highlighted: boolean) {
   const theme = useTheme()
-  const backgroundColor = useMemo<string>(() => {
-    if (theme.dark) {
-      if (highlighted) {
-        return theme.colors.primaryContainer
-      }
-      return theme.colors.surfaceVariant
-    }
-
-    if (highlighted) {
-      return theme.colors.secondaryContainer
-    }
-    return theme.colors.surfaceVariant
-  }, [highlighted, theme])
-
-  const color = useMemo<string>(() => {
-    if (!highlighted) {
-      return theme.colors.onSurface
-    }
-    return theme.colors.onPrimaryContainer
-  }, [highlighted, theme])
+  // M3: primaryContainer / surfaceContainerHighest (Paper: surfaceVariant)
+  const backgroundColor = highlighted
+    ? theme.colors.primaryContainer
+    : theme.colors.surfaceVariant
+  const color = highlighted
+    ? theme.colors.onPrimaryContainer
+    : theme.colors.onSurface
 
   return { backgroundColor, color }
 }

--- a/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/AnimatedCrossView.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`renders AnimatedCrossView 1`] = `
     pointerEvents="auto"
     style={
       {
-        "backgroundColor": "rgba(255, 251, 254, 1)",
+        "backgroundColor": "rgb(238, 232, 244)",
         "left": 0,
         "opacity": 1,
         "position": "absolute",

--- a/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/Calendar.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`renders Calendar 1`] = `
           "zIndex": 100,
         },
         {
-          "backgroundColor": "rgba(255, 251, 254, 1)",
+          "backgroundColor": "rgb(238, 232, 244)",
         },
         {
           "opacity": 0,

--- a/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarEdit.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`renders CalendarEdit 1`] = `
               },
               false,
               {
-                "backgroundColor": "rgba(255, 251, 254, 1)",
+                "backgroundColor": "rgb(238, 232, 244)",
                 "borderColor": "rgba(121, 116, 126, 1)",
                 "borderRadius": 4,
                 "borderWidth": 1,
@@ -127,7 +127,7 @@ exports[`renders CalendarEdit 1`] = `
                   numberOfLines={1}
                   style={
                     {
-                      "backgroundColor": "rgba(255, 251, 254, 1)",
+                      "backgroundColor": "rgb(238, 232, 244)",
                       "color": "transparent",
                       "fontFamily": "System",
                       "fontSize": 16,

--- a/src/__tests__/Date/__snapshots__/CalendarHeader.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarHeader.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`renders CalendarHeader 1`] = `
           "height": 44,
         },
         {
-          "backgroundColor": "rgba(255, 251, 254, 1)",
+          "backgroundColor": "rgb(238, 232, 244)",
         },
       ]
     }

--- a/src/__tests__/Date/__snapshots__/CalendarHeader.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/CalendarHeader.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`renders CalendarHeader 1`] = `
       [
         {
           "alignItems": "center",
-          "backgroundColor": "#fff",
           "flexDirection": "row",
           "height": 44,
         },
@@ -57,10 +56,9 @@ exports[`renders CalendarHeader 1`] = `
             [
               {
                 "fontSize": 14,
-                "opacity": 0.7,
               },
               {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(73, 69, 79, 1)",
                 "fontFamily": "System",
                 "fontSize": 12,
                 "fontWeight": "400",
@@ -102,10 +100,9 @@ exports[`renders CalendarHeader 1`] = `
             [
               {
                 "fontSize": 14,
-                "opacity": 0.7,
               },
               {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(73, 69, 79, 1)",
                 "fontFamily": "System",
                 "fontSize": 12,
                 "fontWeight": "400",
@@ -147,10 +144,9 @@ exports[`renders CalendarHeader 1`] = `
             [
               {
                 "fontSize": 14,
-                "opacity": 0.7,
               },
               {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(73, 69, 79, 1)",
                 "fontFamily": "System",
                 "fontSize": 12,
                 "fontWeight": "400",
@@ -192,10 +188,9 @@ exports[`renders CalendarHeader 1`] = `
             [
               {
                 "fontSize": 14,
-                "opacity": 0.7,
               },
               {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(73, 69, 79, 1)",
                 "fontFamily": "System",
                 "fontSize": 12,
                 "fontWeight": "400",
@@ -237,10 +232,9 @@ exports[`renders CalendarHeader 1`] = `
             [
               {
                 "fontSize": 14,
-                "opacity": 0.7,
               },
               {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(73, 69, 79, 1)",
                 "fontFamily": "System",
                 "fontSize": 12,
                 "fontWeight": "400",
@@ -282,10 +276,9 @@ exports[`renders CalendarHeader 1`] = `
             [
               {
                 "fontSize": 14,
-                "opacity": 0.7,
               },
               {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(73, 69, 79, 1)",
                 "fontFamily": "System",
                 "fontSize": 12,
                 "fontWeight": "400",
@@ -327,10 +320,9 @@ exports[`renders CalendarHeader 1`] = `
             [
               {
                 "fontSize": 14,
-                "opacity": 0.7,
               },
               {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(73, 69, 79, 1)",
                 "fontFamily": "System",
                 "fontSize": 12,
                 "fontWeight": "400",

--- a/src/__tests__/Date/__snapshots__/DayName.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DayName.test.tsx.snap
@@ -29,10 +29,9 @@ exports[`renders DayName 1`] = `
         [
           {
             "fontSize": 14,
-            "opacity": 0.7,
           },
           {
-            "color": "rgba(28, 27, 31, 1)",
+            "color": "rgba(73, 69, 79, 1)",
             "fontFamily": "System",
             "fontSize": 12,
             "fontWeight": "400",

--- a/src/__tests__/Date/__snapshots__/DayNames.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DayNames.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders DayNames 1`] = `
         "height": 44,
       },
       {
-        "backgroundColor": "rgba(255, 251, 254, 1)",
+        "backgroundColor": "rgb(238, 232, 244)",
       },
     ]
   }

--- a/src/__tests__/Date/__snapshots__/DayNames.test.tsx.snap
+++ b/src/__tests__/Date/__snapshots__/DayNames.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`renders DayNames 1`] = `
     [
       {
         "alignItems": "center",
-        "backgroundColor": "#fff",
         "flexDirection": "row",
         "height": 44,
       },
@@ -45,10 +44,9 @@ exports[`renders DayNames 1`] = `
           [
             {
               "fontSize": 14,
-              "opacity": 0.7,
             },
             {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
               "fontSize": 12,
               "fontWeight": "400",
@@ -90,10 +88,9 @@ exports[`renders DayNames 1`] = `
           [
             {
               "fontSize": 14,
-              "opacity": 0.7,
             },
             {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
               "fontSize": 12,
               "fontWeight": "400",
@@ -135,10 +132,9 @@ exports[`renders DayNames 1`] = `
           [
             {
               "fontSize": 14,
-              "opacity": 0.7,
             },
             {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
               "fontSize": 12,
               "fontWeight": "400",
@@ -180,10 +176,9 @@ exports[`renders DayNames 1`] = `
           [
             {
               "fontSize": 14,
-              "opacity": 0.7,
             },
             {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
               "fontSize": 12,
               "fontWeight": "400",
@@ -225,10 +220,9 @@ exports[`renders DayNames 1`] = `
           [
             {
               "fontSize": 14,
-              "opacity": 0.7,
             },
             {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
               "fontSize": 12,
               "fontWeight": "400",
@@ -270,10 +264,9 @@ exports[`renders DayNames 1`] = `
           [
             {
               "fontSize": 14,
-              "opacity": 0.7,
             },
             {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
               "fontSize": 12,
               "fontWeight": "400",
@@ -315,10 +308,9 @@ exports[`renders DayNames 1`] = `
           [
             {
               "fontSize": 14,
-              "opacity": 0.7,
             },
             {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
               "fontSize": 12,
               "fontWeight": "400",

--- a/src/__tests__/Time/__snapshots__/AmPmSwitcher.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/AmPmSwitcher.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`renders AmPmSwitcher 1`] = `
             "justifyContent": "center",
           },
           {
-            "backgroundColor": "rgba(234, 221, 255, 1)",
+            "backgroundColor": "rgba(255, 216, 228, 1)",
           },
         ]
       }
@@ -99,7 +99,7 @@ exports[`renders AmPmSwitcher 1`] = `
             },
             [
               {
-                "color": "rgba(73, 69, 79, 1)",
+                "color": "rgba(49, 17, 29, 1)",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "500",
@@ -179,7 +179,7 @@ exports[`renders AmPmSwitcher 1`] = `
             "justifyContent": "center",
           },
           {
-            "backgroundColor": "rgba(255, 251, 254, 1)",
+            "backgroundColor": "transparent",
           },
         ]
       }

--- a/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInput.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`renders TimeInput 1`] = `
         "width": 96,
       },
       {
-        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "backgroundColor": "rgba(234, 221, 255, 1)",
         "borderColor": "rgba(33, 0, 93, 1)",
         "borderRadius": 8,
         "borderWidth": 2,

--- a/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimeInputs.test.tsx.snap
@@ -3,13 +3,10 @@
 exports[`renders TimeInputs 1`] = `
 <View
   style={
-    [
-      {
-        "alignItems": "center",
-        "flexDirection": "row",
-      },
-      false,
-    ]
+    {
+      "alignItems": "center",
+      "flexDirection": "row",
+    }
   }
 >
   <View

--- a/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
+++ b/src/__tests__/Time/__snapshots__/TimePicker.test.tsx.snap
@@ -11,13 +11,10 @@ exports[`renders TimePicker 1`] = `
 >
   <View
     style={
-      [
-        {
-          "alignItems": "center",
-          "flexDirection": "row",
-        },
-        false,
-      ]
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+      }
     }
   >
     <View
@@ -333,7 +330,7 @@ exports[`renders TimePicker 1`] = `
                 "justifyContent": "center",
               },
               {
-                "backgroundColor": "rgba(234, 221, 255, 1)",
+                "backgroundColor": "rgba(255, 216, 228, 1)",
               },
             ]
           }
@@ -357,7 +354,7 @@ exports[`renders TimePicker 1`] = `
                 },
                 [
                   {
-                    "color": "rgba(73, 69, 79, 1)",
+                    "color": "rgba(49, 17, 29, 1)",
                     "fontFamily": "System",
                     "fontSize": 16,
                     "fontWeight": "500",
@@ -437,7 +434,7 @@ exports[`renders TimePicker 1`] = `
                 "justifyContent": "center",
               },
               {
-                "backgroundColor": "rgba(255, 251, 254, 1)",
+                "backgroundColor": "transparent",
               },
             ]
           }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -26,7 +26,7 @@ export function useLatest<T>(value: T) {
 
 export function useHeaderBackgroundColor() {
   const theme = useTheme()
-  return theme.colors.surface
+  return theme.colors.elevation.level3
 }
 
 export function useHeaderTextColor() {


### PR DESCRIPTION
# Summary

There are a couple fixes here that align the date and time pickers with the MD3 specs.

## Fix 1 (Color standardization)
The date and time pickers now have the same background color

| Before | After |
| --- | --- |
| <img height="500" alt="simulator_screenshot_F7710CF0-8956-4275-B042-8AE87F750A4D" src="https://github.com/user-attachments/assets/e8edf43e-f570-4c3a-96f1-e801f3a70073" />  | <img height="500" alt="simulator_screenshot_9E47497E-C4D9-4A50-AE52-02E132433D1F" src="https://github.com/user-attachments/assets/befe55ff-a097-46ac-a486-79492fe61fdd" /> |

## Fix 2 (Horizontal AM/PM Switch on Landscape)
The aligns with MD3 Specs. Initially we were using a vertical switch which was incorrect.

| Before | After | MD3 |
| --- | --- | --- |
| <img width="500" alt="Screenshot 2026-07-23 at 1 10 17 PM" src="https://github.com/user-attachments/assets/e55162d5-186d-4cfd-bbd2-bd5d3523931c" /> | <img width="655" height="454" alt="Screenshot 2026-07-23 at 1 11 08 PM" src="https://github.com/user-attachments/assets/5e246a77-2925-4f95-b7fd-d202a42fba19" /> | <img width="500" alt="Screenshot 2026-07-23 at 1 06 20 PM" src="https://github.com/user-attachments/assets/3a6c155d-e33a-426f-9f42-0eabda1b9209" /> |

## Fix 3 (Tighten up digital time for 24 hour picker input)

| Before | After | MD3 |
| --- | --- | --- |
| <img width="500" alt="Screenshot 2026-07-23 at 1 27 53 PM" src="https://github.com/user-attachments/assets/0cc6eff8-b04b-47e1-bb68-6a26cb94e520" /> | <img width="500" alt="Screenshot 2026-07-23 at 1 28 14 PM" src="https://github.com/user-attachments/assets/123fddda-0779-4c6f-9600-de5f06de7243" /> | <img width="500" alt="Screenshot 2026-07-23 at 1 28 37 PM" src="https://github.com/user-attachments/assets/f686654c-0ff2-4954-9df5-81dd04fc82a5" /> |