### PR TITLE
Add MD3 divider between date picker header and calendar

### DIFF
--- a/src/Date/DatePickerModalHeaderBackground.tsx
+++ b/src/Date/DatePickerModalHeaderBackground.tsx
@@ -1,4 +1,5 @@
-import { Animated, StyleSheet } from 'react-native'
+import { Animated } from 'react-native'
+import { Divider } from 'react-native-paper'
 import { useHeaderBackgroundColor } from '../shared/utils'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
@@ -12,22 +13,14 @@ export default function DatePickerModalHeaderBackground({
 
   return (
     <Animated.View
-      style={[
-        styles.animated,
-        {
-          backgroundColor,
-          paddingLeft: insets.left,
-          paddingRight: insets.right,
-        },
-      ]}
+      style={{
+        backgroundColor,
+        paddingLeft: insets.left,
+        paddingRight: insets.right,
+      }}
     >
       {children}
+      <Divider />
     </Animated.View>
   )
 }
-
-const styles = StyleSheet.create({
-  animated: {
-    elevation: 4,
-  },
-})


### PR DESCRIPTION
# Summary

Fixes an existing bug where the divider was missing from date picker and on Android it was even showing shadow.

| Before | After | MD3 |
| --- | --- | --- |
| <img width="500" alt="Screenshot_1784836096" src="https://github.com/user-attachments/assets/b7320a1d-fcb1-4601-97d9-4632a71e1a59" /> | <img width="500" alt="Screenshot_1784836297" src="https://github.com/user-attachments/assets/e53210f1-6129-4dc7-9f6b-37952ac85f24" /> | <img width="500" alt="Screenshot 2026-07-23 at 3 56 19 PM" src="https://github.com/user-attachments/assets/1dc938b9-7de5-4b3a-bc5e-a8ee21e35636" /> |
