### PR TITLE
Align date picker modal corner radius with MD3 extra-large

### DIFF
--- a/src/Date/DatePickerModal.tsx
+++ b/src/Date/DatePickerModal.tsx
@@ -138,14 +138,14 @@ const styles = StyleSheet.create({
   modalContentBig: {
     maxWidth: 400,
     maxHeight: 600,
-    borderRadius: 10,
+    borderRadius: 28,
     width: '100%',
     overflow: 'hidden',
   },
   modalContentFormSheet: {
     maxWidth: 520,
     maxHeight: 600,
-    borderRadius: 10,
+    borderRadius: 28,
     width: '100%',
     overflow: 'hidden',
   },


### PR DESCRIPTION
# Summary

Fixes an existing bug where the divider was missing from date picker and on Android it was even showing shadow.

| Before | After | MD3 |
| --- | --- | --- |
| <img width="500" alt="Screenshot 2026-08-08 at 6 09 13 PM" src="https://github.com/user-attachments/assets/002eb669-dd14-44b0-8ab2-8a7a0c20015d" /> | <img width="500" alt="Screenshot 2026-08-08 at 6 09 36 PM" src="https://github.com/user-attachments/assets/da139225-169b-4045-9930-2070dfd43706" /> | <img width="500" alt="Screenshot 2026-08-08 at 6 10 29 PM" src="https://github.com/user-attachments/assets/59e59373-af4e-445a-b2a2-b9ae5ba38f99" /> |







